### PR TITLE
Generate fresh names for top-level parameters to derived generators

### DIFF
--- a/Plausible/IR/Prelude.lean
+++ b/Plausible/IR/Prelude.lean
@@ -12,6 +12,20 @@ open Except
 
 namespace Plausible.IR
 
+-- Enhanced debug function
+def debugLocalContext : MetaM Unit := do
+  let localCtx ← getLCtx
+  logInfo m!"=== LOCAL CONTEXT DEBUG ==="
+  logInfo m!"Local context size: {localCtx.size}"
+  logInfo m!"Local context is empty: {localCtx.isEmpty}"
+
+  if !localCtx.isEmpty then
+    for localDecl in localCtx do
+      if !localDecl.isImplementationDetail then
+        logInfo m!"  {repr localDecl.fvarId}: {localDecl.userName} : {localDecl.type}"
+  else
+    logInfo m!"❌ Local context is completely empty!"
+
 def type_of_Name (name : Name) : MetaM Expr := do
   -- Try to get constant info first (for definitions, theorems, etc)
   match (← getEnv).find? name with

--- a/Plausible/IR/Renaming.lean
+++ b/Plausible/IR/Renaming.lean
@@ -158,4 +158,4 @@ def testSimpleRenaming : MetaM Unit := do
         logInfo m!"After renaming - aux call: {renamedAuxCall}"
 
 
-#eval testSimpleRenaming
+-- #eval testSimpleRenaming

--- a/Plausible/New/DeriveGenerator.lean
+++ b/Plausible/New/DeriveGenerator.lean
@@ -160,14 +160,16 @@ def mkTopLevelGenerator (baseGenerators : TSyntax `term) (inductiveGenerators : 
     innerParams := innerParams.push initSizeParam
     innerParams := innerParams.push sizeParam
 
-    let mut paramIdents := #[]
+    let mut outerParams := #[]
     for (paramName, paramType) in paramInfo do
       if paramName != targetVar then
-        -- TODO: add `"_0"` to the end of `paramName` (same as what QuickChick does)
-        let paramIdent := mkIdent paramName
-        paramIdents := paramIdents.push paramIdent
+        let outerParamIdent := mkIdent paramName
+        outerParams := outerParams.push outerParamIdent
 
-        let innerParam ← `(Term.letIdBinder| ($paramIdent : $paramType))
+        -- TODO: add `"_0"` to the end of `paramName` (same as what QuickChick does)c
+        let innerParamIdent := mkIdent $ Name.appendAfter paramName "_0"
+
+        let innerParam ← `(Term.letIdBinder| ($innerParamIdent : $paramType))
         innerParams := innerParams.push innerParam
 
     -- Produce a fresh name for the `size` argument for the lambda
@@ -181,7 +183,7 @@ def mkTopLevelGenerator (baseGenerators : TSyntax `term) (inductiveGenerators : 
         $genSizedSTIdent:ident :=
           let rec $auxArbIdent:ident $innerParams* : $generatorType :=
             $matchExpr
-          fun $freshSizeIdent => $auxArbIdent $freshSizeIdent $freshSizeIdent $paramIdents*)
+          fun $freshSizeIdent => $auxArbIdent $freshSizeIdent $freshSizeIdent $outerParams*)
 
 
 @[command_elab derive_generator]

--- a/Plausible/New/DeriveGenerator.lean
+++ b/Plausible/New/DeriveGenerator.lean
@@ -163,6 +163,7 @@ def mkTopLevelGenerator (baseGenerators : TSyntax `term) (inductiveGenerators : 
     let mut paramIdents := #[]
     for (paramName, paramType) in paramInfo do
       if paramName != targetVar then
+        -- TODO: add `"_0"` to the end of `paramName` (same as what QuickChick does)
         let paramIdent := mkIdent paramName
         paramIdents := paramIdents.push paramIdent
 

--- a/Plausible/New/DeriveGenerator.lean
+++ b/Plausible/New/DeriveGenerator.lean
@@ -160,14 +160,16 @@ def mkTopLevelGenerator (baseGenerators : TSyntax `term) (inductiveGenerators : 
     innerParams := innerParams.push initSizeParam
     innerParams := innerParams.push sizeParam
 
+    -- Outer params are for the top-level lambda function which invokes `aux_arb`
     let mut outerParams := #[]
     for (paramName, paramType) in paramInfo do
       if paramName != targetVar then
         let outerParamIdent := mkIdent paramName
         outerParams := outerParams.push outerParamIdent
 
-        -- TODO: add `"_0"` to the end of `paramName` (same as what QuickChick does)c
-        let innerParamIdent := mkIdent $ Name.appendAfter paramName "_0"
+        -- Each parameter to the inner `aux_arb` function needs to be a fresh name
+        -- (so that if we pattern match on the parameter, we avoid pattern variables from shadowing it)
+        let innerParamIdent := mkIdent $ genFreshName (Array.map Prod.fst paramInfo) paramName
 
         let innerParam ← `(Term.letIdBinder| ($innerParamIdent : $paramType))
         innerParams := innerParams.push innerParam

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -35,4 +35,19 @@ def sizeIdent : Ident := mkIdent $ Name.mkStr1 "size"
 def mkFreshAccessibleIdent (localCtx : LocalContext) (name : Name) : Ident :=
   mkIdent $ LocalContext.getUnusedName localCtx name
 
+/-- `genFreshName existingNames namePrefix` produces a thunked function
+    that produces a fresh name (with prefix `namePrefix`) that are guaranteed to be
+    not within the existing set of names
+    - Note: the body of this function operates in the identity monad since
+      we want local mutable state and access to the syntactic sugar
+      provided by `while` loops -/
+def genFreshName (existingNames : Array Name) (namePrefix : Name) : Name :=
+  Id.run do
+    let mut count := 0
+    let mut freshName := Name.appendAfter namePrefix s!"_{count}"
+    while (existingNames.contains freshName) do
+      count := count + 1
+      freshName := Name.appendAfter namePrefix s!"_{count}"
+    return freshName
+
 end Idents

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -111,8 +111,7 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
       if !subGenerator.inputsToMatch.isEmpty then
         let mut cases := #[]
         -- For now, we assume there is only one scrutinee
-        -- TODO: append `"_0"` to the end of the name of each scrutinee to match the renamed inputs to `aux_arb`
-        let scrutinee := mkIdent $ Name.appendAfter (Name.mkStr1 subGenerator.inputsToMatch[0]!) "_0"
+        let scrutinee := mkIdent $ genFreshName (Name.mkStr1 <$> subGenerator.inputsToMatch) (Name.mkStr1 subGenerator.inputsToMatch[0]!)
 
         for patternExpr in subGenerator.matchCases do
           let pattern ← PrettyPrinter.delab patternExpr

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -111,12 +111,10 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
       if !subGenerator.inputsToMatch.isEmpty then
         let mut cases := #[]
         -- For now, we assume there is only one scrutinee
+        -- TODO: append `"_0"` to the end of the name of each scrutinee to match the renamed inputs to `aux_arb`
         let scrutinee := mkIdent $ Name.mkStr1 subGenerator.inputsToMatch[0]!
 
         for patternExpr in subGenerator.matchCases do
-          -- TODO: if the scrutinee appears in the pattern, rename the pattern to avoid name clashes?
-          -- Right now, the derived generator works due to shadowing, but not sure if we should judiciously rename
-          -- free variables in the `generatorBody` (this would be somewhat laborious)
           let pattern ← PrettyPrinter.delab patternExpr
           let case ← `(Term.matchAltExpr| | $pattern:term => $generatorBody:term)
           cases := cases.push case

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -112,7 +112,7 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
         let mut cases := #[]
         -- For now, we assume there is only one scrutinee
         -- TODO: append `"_0"` to the end of the name of each scrutinee to match the renamed inputs to `aux_arb`
-        let scrutinee := mkIdent $ Name.mkStr1 subGenerator.inputsToMatch[0]!
+        let scrutinee := mkIdent $ Name.appendAfter (Name.mkStr1 subGenerator.inputsToMatch[0]!) "_0"
 
         for patternExpr in subGenerator.matchCases do
           let pattern ← PrettyPrinter.delab patternExpr

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -19,6 +19,9 @@ open GenSizedSuchThat OptionTGen
   (Note: you may need to comment out the typeclass instances in `Trees.lean` if Lean complains about overlapping instances.)
 -/
 
+-- #derive_generator (fun (t : Tree) => balanced n t)
+-- #derive_generator (fun (t : Tree) => bst lo hi t)
+
 -- TODO: update derived generator to use this template
 -- def aux_arb a1 a2 size :=
 --   match size with


### PR DESCRIPTION
Each parameter to the inner `aux_arb` function of a derived generator needs to be a fresh name, so that if we pattern match on the parameter, we prevent pattern variables from shadowing it. This PR ensures that top-level parameters have fresh names.