### PR TITLE
Produce pattern match which checks variable equalities

### DIFF
--- a/Plausible/IR/Constructor.lean
+++ b/Plausible/IR/Constructor.lean
@@ -380,26 +380,29 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
     - `vars` is a list of free variables that were produced during the `check_IR` block
     - e.g. `vars = ["1", "2", ...]`
 -/
-def backtrackElem_if_return_producer (backtrackElem : SubGeneratorInfo) (indentation : String) (vars: List String) (monad: String :="IO"): MetaM String := do
+def backtrackElem_if_return_producer (subGeneratorInfo : SubGeneratorInfo) (indentation : String) (vars: List String) (monad: String :="IO"): MetaM String := do
+  logWarning "inside backtrackElem_if_return_producer"
+  logWarning m!"subGeneratorInfo = {subGeneratorInfo}"
+
   let mut out := ""
-  if backtrackElem.variableEqualities.size + backtrackElem.groupedActions.checkNonInductiveActions.size + backtrackElem.groupedActions.checkInductiveActions.size > 0 then
+  if subGeneratorInfo.variableEqualities.size + subGeneratorInfo.groupedActions.checkNonInductiveActions.size + subGeneratorInfo.groupedActions.checkInductiveActions.size > 0 then
     out := out ++ indentation ++ "if "
   for j in vars do
     out := out ++ "check" ++ j ++ " && "
-  for i in backtrackElem.variableEqualities do
+  for i in subGeneratorInfo.variableEqualities do
     out := out ++  "(" ++ toString (i.1.name) ++ " == " ++ toString (i.2.name) ++ ") && "
-  for gcc in backtrackElem.groupedActions.checkNonInductiveActions do
+  for gcc in subGeneratorInfo.groupedActions.checkNonInductiveActions do
     out := out ++ (← actionToCode gcc monad) ++ " && "
-  if backtrackElem.variableEqualities.size + backtrackElem.groupedActions.checkNonInductiveActions.size + backtrackElem.groupedActions.checkInductiveActions.size > 0 then
+  if subGeneratorInfo.variableEqualities.size + subGeneratorInfo.groupedActions.checkNonInductiveActions.size + subGeneratorInfo.groupedActions.checkInductiveActions.size > 0 then
     out := ⟨out.data.dropLast.dropLast.dropLast⟩ ++ "\n" ++ indentation ++  "then "
-  for gcc in backtrackElem.groupedActions.ret_list do
+  for gcc in subGeneratorInfo.groupedActions.ret_list do
     out := out ++ indentation ++ (← actionToCode gcc monad)
-  if backtrackElem.variableEqualities.size + backtrackElem.groupedActions.checkNonInductiveActions.size + backtrackElem.groupedActions.checkInductiveActions.size + backtrackElem.groupedActions.iflet_list.size > 0 then
+  if subGeneratorInfo.variableEqualities.size + subGeneratorInfo.groupedActions.checkNonInductiveActions.size + subGeneratorInfo.groupedActions.checkInductiveActions.size + subGeneratorInfo.groupedActions.iflet_list.size > 0 then
     let monad_fail := if monad = "IO" then "throw (IO.userError \"fail at checkstep\")" else "return none"
     out := out ++ "\n" ++ monad_fail
-  if backtrackElem.inputsToMatch.size > 0 then
+  if subGeneratorInfo.inputsToMatch.size > 0 then
     let monad_fail := if monad = "IO" then "throw (IO.userError \"fail\")" else "return none"
-    out := out ++ "\n| " ++ makeUnderscores_commas backtrackElem.inputsToMatch.size ++ " => " ++ monad_fail
+    out := out ++ "\n| " ++ makeUnderscores_commas subGeneratorInfo.inputsToMatch.size ++ " => " ++ monad_fail
 
   return out
 

--- a/Plausible/IR/GCCall.lean
+++ b/Plausible/IR/GCCall.lean
@@ -126,7 +126,7 @@ def separateFVars (hyp : Expr) : MetaM DecomposedInductiveHypothesis := do
     let mut i := 0
     let mut currentFV := fv
     while (numMatchingFVars newHyp currentFV > 1) do
-      let newName := Name.mkNum fv.name i
+      let newName := Name.appendAfter fv.name s!"_{i}"
       let newFVarId := FVarId.mk newName
       newHyp ← subst_first_fVar newHyp currentFV tempfvarid
       newHyp := newHyp.replaceFVarId currentFV (mkFVar newFVarId)

--- a/Plausible/IR/Generator.lean
+++ b/Plausible/IR/Generator.lean
@@ -68,11 +68,13 @@ def elabGetProducer : CommandElab := fun stx => do
       let pos := TSyntax.getNat t3
       let btnum := TSyntax.getNat t4
       let producer ← get_producer inductiveInfo inpname pos btnum
-      -- logInfo producer
+      logWarning producer
   | _ => throwError "Invalid syntax"
 
 -- #gen_producer typing with_name ["Γ", "e", "τ"] for_arg 2 backtrack 100
-#gen_producer balanced with_name ["n", "T"] for_arg 1 backtrack 100
+-- #gen_producer lookup with_name ["Γ", "x", "τ"] for_arg 1 backtrack 100
+-- #gen_producer balanced with_name ["n", "T"] for_arg 1 backtrack 100
+
 -- #gen_producer bst with_name ["lo", "hi", "T"] for_arg 2 backtrack 100
 
 

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -14,7 +14,7 @@ def auxArbFn : Ident := mkIdent $ Name.mkStr1 "aux_arb"
 def genSizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "GenSizedSuchThat"
 def genSizedSTIdent : Ident := mkIdent $ Name.mkStr1 "genSizedST"
 def qualifiedGenSizedSTIdent : Ident := mkIdent $ Name.mkStr2 "GenSuchThat" "genST"
-
+def qualifiedDecOptIdent : Ident := mkIdent $ Name.mkStr2 "DecOpt" "decOpt"
 
 /-- `Ident` representing `OptionT.fail`-/
 def failFn : Ident := mkIdent $ Name.mkStr2 "OptionT" "fail"

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -192,8 +192,8 @@ def gen_lookup (Γ : List type) (τ : type) : Nat → OptionT Plausible.Gen Nat 
               (fun _ =>
                 match Γ_0 with
                 | [] => OptionT.fail
-                | _ :: Γ0 => do
-                  let x ← aux_arb initSize size' Γ0 τ_0
+                | _ :: Γ => do
+                  let x ← aux_arb initSize size' Γ τ_0
                   return Nat.succ x))]
   fun size => aux_arb size size Γ τ
 

--- a/Plausible/New/TSyntaxCombinators.lean
+++ b/Plausible/New/TSyntaxCombinators.lean
@@ -36,3 +36,6 @@ def mkIfExprWithNaryAnd (predicates : Array Term)
 /-- Creates a match expression -/
 def mkMatchExpr (scrutinee: Ident) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
   `(match $scrutinee:ident with $cases:matchAlt*)
+
+def mkMatchExprWithScrutineeTerm (scrutinee: TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
+  `(match $scrutinee:term with $cases:matchAlt*)

--- a/Plausible/New/TSyntaxCombinators.lean
+++ b/Plausible/New/TSyntaxCombinators.lean
@@ -33,9 +33,16 @@ def mkIfExprWithNaryAnd (predicates : Array Term)
       List.foldlM (fun acc pred => `($acc && $pred)) (init := p) ps
   `(doElem| if $condition then $trueBranch:doElem else $elseBranch:doElem)
 
-/-- Creates a match expression -/
-def mkMatchExpr (scrutinee: Ident) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
+/-- Creates a match expression (represented as a `TSyntax term`),
+    where the `scrutinee` is an `Ident` and the `cases` are specified as an array of `matchAlt`s -/
+def mkMatchExpr (scrutinee : Ident) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
   `(match $scrutinee:ident with $cases:matchAlt*)
 
-def mkMatchExprWithScrutineeTerm (scrutinee: TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
+/-- Variant of `mkMatchExpr` where the `scrutinee` is a `TSyntax term` rather than an `Ident` -/
+def mkMatchExprWithScrutineeTerm (scrutinee : TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `term) :=
   `(match $scrutinee:term with $cases:matchAlt*)
+
+/-- Variant of `mkMatchExpr` where the `scrutinee` is a `TSyntax term`, and the resultant match expression
+    is a `doElem` (i.e. it is part of a monadic `do`-block) -/
+def mkDoElemMatchExpr (scrutinee : TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `doElem) :=
+  `(doElem| match $scrutinee:term with $cases:matchAlt*)

--- a/Test.lean
+++ b/Test.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/
-import Test.Tactic
-import Test.Testable
+-- import Test.Tactic
+-- import Test.Testable
 import Test.DeriveBSTGenerator
 import Test.DeriveBalancedTreeGenerator
 import Test.DeriveRegexGenerator

--- a/Test.lean
+++ b/Test.lean
@@ -8,3 +8,4 @@ import Test.Testable
 import Test.DeriveBSTGenerator
 import Test.DeriveBalancedTreeGenerator
 import Test.DeriveRegexGenerator
+import Test.DeriveSTLCGenerator

--- a/Test/DeriveSTLCGenerator.lean
+++ b/Test/DeriveSTLCGenerator.lean
@@ -38,9 +38,12 @@ info: Try this generator: instance : GenSizedSuchThat Nat (fun x => lookup Γ x 
                   | _ => OptionT.fail)),
             (Nat.succ size',
               OptionTGen.thunkGen
-                (fun _ => do
-                  let n ← aux_arb initSize size' Γ τ
-                  return Nat.succ n))]
+                (fun _ =>
+                  match Γ_0 with
+                  | τ' :: Γ => do
+                    let n ← aux_arb initSize size' Γ τ
+                    return Nat.succ n
+                  | _ => OptionT.fail))]
     fun size => aux_arb size size Γ τ
 -/
 #guard_msgs(info, drop warning) in

--- a/Test/DeriveSTLCGenerator.lean
+++ b/Test/DeriveSTLCGenerator.lean
@@ -1,0 +1,47 @@
+import Plausible.Gen
+import Plausible.New.OptionTGen
+import Plausible.New.DecOpt
+import Plausible.New.GenSizedSuchThat
+import Plausible.New.DeriveGenerator
+
+open GenSizedSuchThat OptionTGen
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this generator: instance : GenSizedSuchThat Nat (fun x => lookup Γ x τ) where
+  genSizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) (Γ_0 : List type) (τ_0 : type) : OptionT Plausible.Gen Nat :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1,
+              OptionTGen.thunkGen
+                (fun _ =>
+                  match Γ_0 with
+                  | τ :: Γ =>
+                    match DecOpt.decOpt (τ = τ_0) initSize with
+                    | Option.some Bool.true => pure 0
+                    | _ => OptionT.fail
+                  | _ => OptionT.fail)),
+            (1, OptionTGen.thunkGen (fun _ => OptionT.fail))]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1,
+              OptionTGen.thunkGen
+                (fun _ =>
+                  match Γ_0 with
+                  | τ :: Γ =>
+                    match DecOpt.decOpt (τ = τ_0) initSize with
+                    | Option.some Bool.true => pure 0
+                    | _ => OptionT.fail
+                  | _ => OptionT.fail)),
+            (Nat.succ size',
+              OptionTGen.thunkGen
+                (fun _ => do
+                  let n ← aux_arb initSize size' Γ τ
+                  return Nat.succ n))]
+    fun size => aux_arb size size Γ τ
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (x : Nat) => lookup Γ x τ)


### PR DESCRIPTION
This PR adds a helper function `mkVariableEqualityCheckMatchExpr` which constructs a pattern match which checks whether all the equalities in `variableEqualities` hold (using the `DecOpt` instance when performing the equality check), and if so, producing the `retExpr`, otherwise failing (i.e. returning `OptionT.fail`)

For example, if `variableEqualities := [(t, t0)]`, then the following match expression is produced:
```lean
    match DecOpt.decOpt (t = t0) initSize with
    | some true => $retExpr
    | _ => OptionT.fail
```
