### PR TITLE
Deriving Handler Frontend for `Arbitrary` Typeclass

### DIFF
--- a/Plausible/New/DeriveArbitrary.lean
+++ b/Plausible/New/DeriveArbitrary.lean
@@ -203,19 +203,14 @@ def elabDeriveArbitrary : CommandElab := fun stx => do
 
   | _ => throwUnsupportedSyntax
 
-/-- Deriving handler which produces an instance of the `ArbitrarySized` typeclass -/
+/-- Deriving handler which produces an instance of the `ArbitrarySized` typeclass for
+    each type specified in `declNames` -/
 def deriveArbitraryInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
   if (← declNames.allM isInductive) then
-    if h : declNames.size = 1 then
-      let targetTypeName := declNames[0]
-
-      -- Create an instance of the `ArbitrarySized` typeclass
+    for targetTypeName in declNames do
       let typeClassInstance ← mkArbitrarySizedInstance targetTypeName
       elabCommand typeClassInstance
-      return true
-    else
-      throwError "Cannot deriving Arbitrary instances for more than one type simultaneously"
-      return false
+    return true
   else
     throwError "Cannot derive instance of Arbitrary typeclass for non-inductive types"
     return false

--- a/Plausible/New/DeriveArbitrary.lean
+++ b/Plausible/New/DeriveArbitrary.lean
@@ -55,10 +55,123 @@ def getCtorArgsNamesAndTypes (ctorName : Name) : MetaM (Array (Name × Expr)) :=
 
     return argNamesAndTypes
 
+/-- Creates an instance of the `ArbitrarySized` typeclass for an inductive type
+    whose name is given by `targetTypeName`.
+
+    (Note: the main logic for determining the structure of the derived generator
+    is contained in this function.) -/
+def mkArbitrarySizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command) := do
+  -- Obtain Lean's `InductiveVal` data structure, which contains metadata about
+  -- the type corresponding to `targetTypeName`
+  let inductiveVal ← getConstInfoInduct targetTypeName
+
+  -- Fetch the ambient local context, which we need to produce user-accessible fresh names
+  let localCtx ← liftTermElabM $ getLCtx
+
+  -- Produce a fresh name for the `size` argument for the lambda
+  -- at the end of the generator function, as well as the `aux_arb` inner helper function
+  let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
+  let freshSize' := mkFreshAccessibleIdent localCtx `size'
+  let auxArbIdent := mkFreshAccessibleIdent localCtx `aux_arb
+
+  let mut nonRecursiveGenerators := #[]
+  let mut recursiveGenerators := #[]
+  for ctorName in inductiveVal.ctors do
+    let ctorIdent := mkIdent ctorName
+
+    let ctorArgNamesTypes ← liftTermElabM $ getCtorArgsNamesAndTypes ctorName
+
+    if ctorArgNamesTypes.isEmpty then
+      -- Constructor is nullary, we can just use a generator of the form `pure ...`
+      let pureGen ← `($pureFn $ctorIdent)
+      nonRecursiveGenerators := nonRecursiveGenerators.push pureGen
+    else
+      -- Produce a fresh name for each of the args to the constructor
+      let ctorArgNames := Prod.fst <$> ctorArgNamesTypes
+      let freshArgIdents := Lean.mkIdent <$> genFreshNames (existingNames := ctorArgNames) (namePrefixes := ctorArgNames)
+
+      let mut doElems := #[]
+
+      -- Determine whether the constructor has any recursive arguments
+      let ctorIsRecursive ← liftTermElabM $ isConstructorRecursive targetTypeName ctorName
+      if !ctorIsRecursive then
+        -- Call `arbitrary` to generate a random value for each of the arguments
+        for freshIdent in freshArgIdents do
+          let bindExpr ← liftTermElabM $ mkLetBind freshIdent #[arbitraryFn]
+          doElems := doElems.push bindExpr
+      else
+        -- For recursive constructors, we need to examine each argument to see which of them require
+        -- recursive calls to the generator
+        let freshArgIdentsTypes := Array.zip freshArgIdents (Prod.snd <$> ctorArgNamesTypes)
+        for (freshIdent, argType) in freshArgIdentsTypes do
+          -- If the argument's type is the same as the target type,
+          -- produce a recursive call to the generator using `aux_arb`,
+          -- otherwise generate a value using `arbitrary`
+          let bindExpr ←
+            liftTermElabM $
+              if argType.getAppFn.constName == targetTypeName then
+                mkLetBind freshIdent #[auxArbFn, freshSize']
+              else
+                mkLetBind freshIdent #[arbitraryFn]
+          doElems := doElems.push bindExpr
+
+      -- Create an expression `return C x1 ... xn` at the end of the generator, where
+      -- `C` is the constructor name and the `xi` are the generated values for the args
+      let pureExpr ← `(doElem| return $ctorIdent $freshArgIdents*)
+      doElems := doElems.push pureExpr
+
+      -- Put the body of the generator together
+      let generatorBody ← liftTermElabM $ mkDoBlock doElems
+      if !ctorIsRecursive then
+        nonRecursiveGenerators := nonRecursiveGenerators.push generatorBody
+      else
+        recursiveGenerators := recursiveGenerators.push generatorBody
+
+  -- Just use the first non-recursive generator as the default generator
+  let defaultGenerator := nonRecursiveGenerators[0]!
+
+  -- Turn each generator into a thunked function and associate each generator with its weight
+  -- (1 for non-recursive generators, `.succ size'` for recursive generators)
+  let thunkedNonRecursiveGenerators ←
+    Array.mapM (fun generatorBody => `($generatorCombinatorsThunkGenFn (fun _ => $generatorBody))) nonRecursiveGenerators
+
+  let mut weightedThunkedNonRecursiveGens := #[]
+  for thunkedGen in thunkedNonRecursiveGenerators do
+    let thunkedGen ← `((1, $thunkedGen))
+    weightedThunkedNonRecursiveGens := weightedThunkedNonRecursiveGens.push thunkedGen
+
+  let mut weightedThunkedRecursiveGens := #[]
+  for recursiveGen in recursiveGenerators do
+    let thunkedWeightedGen ← `(($succIdent $freshSize', $generatorCombinatorsThunkGenFn (fun _ => $recursiveGen)))
+    weightedThunkedRecursiveGens := weightedThunkedRecursiveGens.push thunkedWeightedGen
+
+  -- Create the cases for the pattern-match on the size argument
+  -- If `size = 0`, pick one of the thunked non-recursive generators
+  let mut caseExprs := #[]
+  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
+  caseExprs := caseExprs.push zeroCase
+
+  -- If `size = .succ size'`, pick a generator (it can be non-recursive or recursive)
+  let mut allThunkedWeightedGenerators ← `([$weightedThunkedNonRecursiveGens,*, $weightedThunkedRecursiveGens,*])
+  let succCase ← `(Term.matchAltExpr| | $succIdent $freshSize' => $frequencyFn $defaultGenerator $allThunkedWeightedGenerators)
+  caseExprs := caseExprs.push succCase
+
+  -- Create function argument for the generator size
+  let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
+  let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
+
+  -- Create an instance of the `ArbitrarySized` typeclass
+  let targetTypeIdent := mkIdent targetTypeName
+  let generatorType ← `($genIdent $targetTypeIdent)
+  `(instance : $arbitrarySizedTypeclass $targetTypeIdent where
+      $unqualifiedArbitrarySizedFn:ident :=
+        let rec $auxArbIdent:ident $sizeParam : $generatorType :=
+          $matchExpr
+      fun $freshSizeIdent => $auxArbIdent $freshSizeIdent)
 
 syntax (name := derive_arbitrary) "#derive_arbitrary" term : command
 
-/-- Derives an instance of the `ArbitrarySized` typeclass -/
+/-- Command elaborator which derives an instance of the `ArbitrarySized` typeclass -/
 @[command_elab derive_arbitrary]
 def elabDeriveArbitrary : CommandElab := fun stx => do
   match stx with
@@ -73,114 +186,10 @@ def elabDeriveArbitrary : CommandElab := fun stx => do
 
     let isInductiveType ← isInductive targetTypeName
     if isInductiveType then
-      let inductiveVal ← getConstInfoInduct targetTypeName
-
-      -- Fetch the ambient local context, which we need to produce user-accessible fresh names
-      let localCtx ← liftTermElabM $ getLCtx
-
-      -- Produce a fresh name for the `size` argument for the lambda
-      -- at the end of the generator function, as well as the `aux_arb` inner helper function
-      let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
-      let freshSize' := mkFreshAccessibleIdent localCtx `size'
-      let auxArbIdent := mkFreshAccessibleIdent localCtx `aux_arb
-
-      let mut nonRecursiveGenerators := #[]
-      let mut recursiveGenerators := #[]
-      for ctorName in inductiveVal.ctors do
-        let ctorIdent := mkIdent ctorName
-
-        let ctorArgNamesTypes ← liftTermElabM $ getCtorArgsNamesAndTypes ctorName
-
-        if ctorArgNamesTypes.isEmpty then
-          -- Constructor is nullary, we can just use a generator of the form `pure ...`
-          let pureGen ← `($pureFn $ctorIdent)
-          nonRecursiveGenerators := nonRecursiveGenerators.push pureGen
-        else
-          -- Produce a fresh name for each of the args to the constructor
-          let ctorArgNames := Prod.fst <$> ctorArgNamesTypes
-          let freshArgIdents := Lean.mkIdent <$> genFreshNames (existingNames := ctorArgNames) (namePrefixes := ctorArgNames)
-
-          let mut doElems := #[]
-
-          -- Determine whether the constructor has any recursive arguments
-          let ctorIsRecursive ← liftTermElabM $ isConstructorRecursive targetTypeName ctorName
-          if !ctorIsRecursive then
-            -- Call `arbitrary` to generate a random value for each of the arguments
-            for freshIdent in freshArgIdents do
-              let bindExpr ← liftTermElabM $ mkLetBind freshIdent #[arbitraryFn]
-              doElems := doElems.push bindExpr
-          else
-            -- For recursive constructors, we need to examine each argument to see which of them require
-            -- recursive calls to the generator
-            let freshArgIdentsTypes := Array.zip freshArgIdents (Prod.snd <$> ctorArgNamesTypes)
-            for (freshIdent, argType) in freshArgIdentsTypes do
-              -- If the argument's type is the same as the target type,
-              -- produce a recursive call to the generator using `aux_arb`,
-              -- otherwise generate a value using `arbitrary`
-              let bindExpr ←
-                liftTermElabM $
-                  if argType.getAppFn.constName == targetTypeName then
-                    mkLetBind freshIdent #[auxArbFn, freshSize']
-                  else
-                    mkLetBind freshIdent #[arbitraryFn]
-              doElems := doElems.push bindExpr
-
-          -- Create an expression `return C x1 ... xn` at the end of the generator, where
-          -- `C` is the constructor name and the `xi` are the generated values for the args
-          let pureExpr ← `(doElem| return $ctorIdent $freshArgIdents*)
-          doElems := doElems.push pureExpr
-
-          -- Put the body of the generator together
-          let generatorBody ← liftTermElabM $ mkDoBlock doElems
-          if !ctorIsRecursive then
-            nonRecursiveGenerators := nonRecursiveGenerators.push generatorBody
-          else
-            recursiveGenerators := recursiveGenerators.push generatorBody
-
-      -- Just use the first non-recursive generator as the default generator
-      let defaultGenerator := nonRecursiveGenerators[0]!
-
-      -- Turn each generator into a thunked function and associate each generator with its weight
-      -- (1 for non-recursive generators, `.succ size'` for recursive generators)
-      let thunkedNonRecursiveGenerators ←
-        Array.mapM (fun generatorBody => `($generatorCombinatorsThunkGenFn (fun _ => $generatorBody))) nonRecursiveGenerators
-
-      let mut weightedThunkedNonRecursiveGens := #[]
-      for thunkedGen in thunkedNonRecursiveGenerators do
-        let thunkedGen ← `((1, $thunkedGen))
-        weightedThunkedNonRecursiveGens := weightedThunkedNonRecursiveGens.push thunkedGen
-
-      let mut weightedThunkedRecursiveGens := #[]
-      for recursiveGen in recursiveGenerators do
-        let thunkedWeightedGen ← `(($succIdent $freshSize', $generatorCombinatorsThunkGenFn (fun _ => $recursiveGen)))
-        weightedThunkedRecursiveGens := weightedThunkedRecursiveGens.push thunkedWeightedGen
-
-      -- Create the cases for the pattern-match on the size argument
-      -- If `size = 0`, pick one of the thunked non-recursive generators
-      let mut caseExprs := #[]
-      let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
-      caseExprs := caseExprs.push zeroCase
-
-      -- If `size = .succ size'`, pick a generator (it can be non-recursive or recursive)
-      let mut allThunkedWeightedGenerators ← `([$weightedThunkedNonRecursiveGens,*, $weightedThunkedRecursiveGens,*])
-      let succCase ← `(Term.matchAltExpr| | $succIdent $freshSize' => $frequencyFn $defaultGenerator $allThunkedWeightedGenerators)
-      caseExprs := caseExprs.push succCase
-
-      -- Create function argument for the generator size
-      let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
-      let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
-
-      -- Create an instance of the `ArbitrarySized` typeclass
-      let generatorType ← `($genIdent $targetTypeIdent)
-      let typeclassInstance ←
-        `(instance : $arbitrarySizedTypeclass $targetTypeIdent where
-            $unqualifiedArbitrarySizedFn:ident :=
-              let rec $auxArbIdent:ident $sizeParam : $generatorType :=
-                $matchExpr
-            fun $freshSizeIdent => $auxArbIdent $freshSizeIdent)
+      let typeClassInstance ← mkArbitrarySizedInstance targetTypeName
 
       -- Pretty-print the derived generator
-      let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeclassInstance)
+      let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
 
       -- Display the code for the derived typeclass instance to the user
       -- & prompt the user to accept it in the VS Code side panel
@@ -188,6 +197,28 @@ def elabDeriveArbitrary : CommandElab := fun stx => do
         (Format.pretty genFormat) (header := "Try this generator: ")
 
       -- Elaborate the typeclass instance and add it to the local context
-      elabCommand typeclassInstance
+      elabCommand typeClassInstance
+    else
+      throwError "Cannot derive Arbitrary instance for non-inductive types"
 
   | _ => throwUnsupportedSyntax
+
+/-- Deriving handler which produces an instance of the `ArbitrarySized` typeclass -/
+def deriveArbitraryInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
+  if (← declNames.allM isInductive) then
+    if h : declNames.size = 1 then
+      let targetTypeName := declNames[0]
+
+      -- Create an instance of the `ArbitrarySized` typeclass
+      let typeClassInstance ← mkArbitrarySizedInstance targetTypeName
+      elabCommand typeClassInstance
+      return true
+    else
+      throwError "Cannot deriving Arbitrary instances for more than one type simultaneously"
+      return false
+  else
+    throwError "Cannot derive instance of Arbitrary typeclass for non-inductive types"
+    return false
+
+initialize
+  registerDerivingHandler ``Arbitrary deriveArbitraryInstanceHandler

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -28,7 +28,6 @@ inductive Foo where
   | FromBitVec : ∀ (n : Nat), BitVec n → String → Foo
   deriving Arbitrary
 
--- #eval runArbitrary (α := Foo) 10
 
 inductive MyList where
   | Nil
@@ -37,6 +36,12 @@ inductive MyList where
 inductive MyListAnon where
   | Nil : MyListAnon
   | Cons : Nat -> MyListAnon -> MyListAnon
+
+-- deriving instance Arbitrary for MyList, MyListAnon
+
+-- #synth Arbitrary MyList
+-- #synth Arbitrary MyListAnon
+
 
 -- #derive_arbitrary MyListAnon
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -12,15 +12,23 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 
 /-- Dummy inductive relation for testing purposes -/
 inductive RGB where
-| Red
-| Green
-| Blue
+  | Red
+  | Green
+  | Blue
+  deriving Arbitrary
 
 inductive Value where
   | none
   | bool (b : Bool)
   | int (i : Int)
   | tensor (shape : List Nat) (dtype : String)
+  deriving Arbitrary
+
+inductive Foo where
+  | FromBitVec : ∀ (n : Nat), BitVec n → String → Foo
+  deriving Arbitrary
+
+-- #eval runArbitrary (α := Foo) 10
 
 inductive MyList where
   | Nil

--- a/Test/DeriveArbitrary/DeriveNKIBinopGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveNKIBinopGenerator.lean
@@ -17,7 +17,21 @@ inductive BinOp where
   | add | sub | mul | div | mod | pow | floor
   -- bitwise
   | lshift | rshift | or | xor | and
-  deriving Repr
+  deriving Repr, Arbitrary
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instArbitrarySizedBinOp -/
+#guard_msgs in
+#synth ArbitrarySized BinOp
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary BinOp
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
 
 /--
 info: Try this generator: instance : ArbitrarySized BinOp where
@@ -72,3 +86,5 @@ info: Try this generator: instance : ArbitrarySized BinOp where
 -/
 #guard_msgs(info, drop warning) in
 #derive_arbitrary BinOp
+
+end CommandElaboratorTest

--- a/Test/DeriveArbitrary/DeriveNKIValueGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveNKIValueGenerator.lean
@@ -17,7 +17,16 @@ inductive Value where
   | string (value : String)
   | ellipsis
   | tensor (shape : List Nat) (dtype : String)
-  deriving Repr
+  deriving Repr, Arbitrary
+
+/-- info: instArbitrarySizedValue -/
+#guard_msgs in
+#synth ArbitrarySized Value
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary Value
+namespace CommandElaboratorTest
 
 /--
 info: Try this generator: instance : ArbitrarySized Value where
@@ -75,3 +84,5 @@ info: Try this generator: instance : ArbitrarySized Value where
 -/
 #guard_msgs(info, drop warning) in
 #derive_arbitrary Value
+
+end CommandElaboratorTest

--- a/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
@@ -8,19 +8,31 @@ open Arbitrary GeneratorCombinators
 
 set_option guard_msgs.diff true
 
-
 /-- An inductive datatype representing regular expressions (where "characters" are `Nat`s).
    Slightly modified from Software Foundations
    See https://softwarefoundations.cis.upenn.edu/lf-current/IndProp.html
    and search for "Case Study: Regular Expressions".
    The `RegExp`s below are non-polymorphic in the character type. -/
 inductive RegExp : Type where
-| EmptySet : RegExp
-| EmptyStr : RegExp
-| Char : Nat → RegExp -- using Nat instead of Char
-| App : RegExp → RegExp → RegExp
-| Union : RegExp → RegExp → RegExp
-| Star : RegExp → RegExp
+  | EmptySet : RegExp
+  | EmptyStr : RegExp
+  | Char : Nat → RegExp -- using Nat instead of Char
+  | App : RegExp → RegExp → RegExp
+  | Union : RegExp → RegExp → RegExp
+  | Star : RegExp → RegExp
+  deriving Repr, Arbitrary
+
+/-- info: instArbitrarySizedRegExp -/
+#guard_msgs in
+#synth ArbitrarySized RegExp
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary RegExp
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
 
 /--
 info: Try this generator: instance : ArbitrarySized RegExp where
@@ -65,3 +77,5 @@ info: Try this generator: instance : ArbitrarySized RegExp where
 -/
 #guard_msgs(info, drop warning) in
 #derive_arbitrary RegExp
+
+end CommandElaboratorTest

--- a/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
@@ -22,6 +22,8 @@ inductive RegExp : Type where
   | Star : RegExp → RegExp
   deriving Repr, Arbitrary
 
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
 /-- info: instArbitrarySizedRegExp -/
 #guard_msgs in
 #synth ArbitrarySized RegExp

--- a/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
+++ b/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
@@ -11,6 +11,9 @@ set_option guard_msgs.diff true
 -- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
 deriving instance Arbitrary for type, term
 
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+-- for both `type` & `term`
+
 /-- info: instArbitrarySizedType_test -/
 #guard_msgs in
 #synth ArbitrarySized type

--- a/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
+++ b/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
@@ -8,6 +8,29 @@ open Arbitrary GeneratorCombinators
 
 set_option guard_msgs.diff true
 
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+deriving instance Arbitrary for type, term
+
+/-- info: instArbitrarySizedType_test -/
+#guard_msgs in
+#synth ArbitrarySized type
+
+/-- info: instArbitrarySizedTerm_test -/
+#guard_msgs in
+#synth ArbitrarySized term
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary type
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary term
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
 /--
 info: Try this generator: instance : ArbitrarySized type where
   arbitrarySized :=
@@ -84,3 +107,5 @@ info: Try this generator: instance : ArbitrarySized term where
 -/
 #guard_msgs(info, drop warning) in
 #derive_arbitrary term
+
+end CommandElaboratorTest

--- a/Test/DeriveArbitrary/DeriveTreeGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveTreeGenerator.lean
@@ -8,6 +8,23 @@ open Arbitrary GeneratorCombinators
 
 set_option guard_msgs.diff true
 
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+deriving instance Arbitrary for Tree
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instArbitrarySizedTree_test -/
+#guard_msgs in
+#synth ArbitrarySized Tree
+
+/-- info: instArbitraryOfArbitrarySized -/
+#guard_msgs in
+#synth Arbitrary Tree
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
 /--
 info: Try this generator: instance : ArbitrarySized Tree where
   arbitrarySized :=
@@ -29,3 +46,5 @@ info: Try this generator: instance : ArbitrarySized Tree where
 -/
 #guard_msgs(info, drop warning) in
 #derive_arbitrary Tree
+
+end CommandElaboratorTest


### PR DESCRIPTION
This PR implements a deriving handler frontend for `Arbitrary`. 
Users can write `deriving Arbitrary` after an inductive type definition like so:

```lean 
inductive Tree where
  ...
  deriving Arbitrary 
```

Alternatively, users can also write `deriving instance Arbitrary for T1, ..., Tn` as a top-level command 
to derive `Arbitrary` instances for types `T1, ..., Tn` simultaneously.