### PR TITLE
Deriving Instance handler for Enumerators

### DIFF
--- a/Plausible/New/Chamelean.lean
+++ b/Plausible/New/Chamelean.lean
@@ -17,4 +17,5 @@ import Plausible.New.STLC
 import Plausible.New.Trees
 import Plausible.New.NKIExperiments
 import Plausible.New.DeriveArbitrary
+import Plausible.New.DeriveEnum
 import Plausible.New.Utils

--- a/Plausible/New/DeriveArbitrary.lean
+++ b/Plausible/New/DeriveArbitrary.lean
@@ -8,20 +8,6 @@ import Plausible.New.Utils
 open Lean Elab Command Meta Term Parser
 open Plausible.IR Idents
 
-/-- `ToMessageData` instance for pretty-printing `ConstructorVal`s -/
-instance : ToMessageData ConstructorVal where
-  toMessageData ctorVal :=
-    let fields := [
-      m!"name := {ctorVal.name}",
-      m!"levelParams := {ctorVal.levelParams}",
-      m!"type := {ctorVal.type}",
-      m!"induct := {ctorVal.induct}",
-      m!"cidx := {ctorVal.cidx}",
-      m!"numParams := {ctorVal.numParams}",
-      m!"numFields := {ctorVal.numFields}",
-      m!"isUnsafe := {ctorVal.isUnsafe}"
-    ]
-    .bracket "{" (.ofList fields) "}"
 
 /-- Takes the name of a constructor for an algebraic data type and returns an array
     containing `(argument_name, argument_type)` pairs.

--- a/Plausible/New/DeriveArbitrary.lean
+++ b/Plausible/New/DeriveArbitrary.lean
@@ -134,7 +134,7 @@ def mkArbitrarySizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `co
   -- Create the cases for the pattern-match on the size argument
   -- If `size = 0`, pick one of the thunked non-recursive generators
   let mut caseExprs := #[]
-  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
+  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultGenCombinatorFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
   caseExprs := caseExprs.push zeroCase
 
   -- If `size = .succ size'`, pick a generator (it can be non-recursive or recursive)
@@ -148,7 +148,7 @@ def mkArbitrarySizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `co
 
   -- Create an instance of the `ArbitrarySized` typeclass
   let targetTypeIdent := mkIdent targetTypeName
-  let generatorType ← `($genIdent $targetTypeIdent)
+  let generatorType ← `($genTypeConstructor $targetTypeIdent)
   `(instance : $arbitrarySizedTypeclass $targetTypeIdent where
       $unqualifiedArbitrarySizedFn:ident :=
         let rec $auxArbIdent:ident $sizeParam : $generatorType :=

--- a/Plausible/New/DeriveEnum.lean
+++ b/Plausible/New/DeriveEnum.lean
@@ -1,0 +1,9 @@
+import Lean
+import Plausible.IR.Prelude
+import Plausible.New.Idents
+import Plausible.New.TSyntaxCombinators
+import Plausible.New.Arbitrary
+import Plausible.New.Utils
+
+open Lean Elab Command Meta Term Parser
+open Plausible.IR Idents

--- a/Plausible/New/DeriveEnum.lean
+++ b/Plausible/New/DeriveEnum.lean
@@ -26,19 +26,18 @@ def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command
   -- at the end of the generator function, as well as the `aux_arb` inner helper function
   let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
   let freshSize' := mkFreshAccessibleIdent localCtx `size'
-  let auxArbIdent := mkFreshAccessibleIdent localCtx `aux_arb
 
-  let mut nonRecursiveGenerators := #[]
-  let mut recursiveGenerators := #[]
+  let mut nonRecursiveEnumerators := #[]
+  let mut recursiveEnumerators := #[]
   for ctorName in inductiveVal.ctors do
     let ctorIdent := mkIdent ctorName
 
     let ctorArgNamesTypes ← liftTermElabM $ getCtorArgsNamesAndTypes ctorName
 
     if ctorArgNamesTypes.isEmpty then
-      -- Constructor is nullary, we can just use a generator of the form `pure ...`
+      -- Constructor is nullary, we can just use an enumerator of the form `pure ...`
       let pureGen ← `($pureFn $ctorIdent)
-      nonRecursiveGenerators := nonRecursiveGenerators.push pureGen
+      nonRecursiveEnumerators := nonRecursiveEnumerators.push pureGen
     else
       -- Produce a fresh name for each of the args to the constructor
       let ctorArgNames := Prod.fst <$> ctorArgNamesTypes
@@ -49,9 +48,9 @@ def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command
       -- Determine whether the constructor has any recursive arguments
       let ctorIsRecursive ← liftTermElabM $ isConstructorRecursive targetTypeName ctorName
       if !ctorIsRecursive then
-        -- Call `arbitrary` to generate a random value for each of the arguments
+        -- Call `enum` to enumerate a random value for each of the arguments
         for freshIdent in freshArgIdents do
-          let bindExpr ← liftTermElabM $ mkLetBind freshIdent #[arbitraryFn]
+          let bindExpr ← liftTermElabM $ mkLetBind freshIdent #[enumFn]
           doElems := doElems.push bindExpr
       else
         -- For recursive constructors, we need to examine each argument to see which of them require
@@ -59,14 +58,14 @@ def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command
         let freshArgIdentsTypes := Array.zip freshArgIdents (Prod.snd <$> ctorArgNamesTypes)
         for (freshIdent, argType) in freshArgIdentsTypes do
           -- If the argument's type is the same as the target type,
-          -- produce a recursive call to the generator using `aux_arb`,
-          -- otherwise generate a value using `arbitrary`
+          -- produce a recursive call to the enumerator using `aux_enum`,
+          -- otherwise enumerate a value using `enum`
           let bindExpr ←
             liftTermElabM $
               if argType.getAppFn.constName == targetTypeName then
-                mkLetBind freshIdent #[auxArbFn, freshSize']
+                mkLetBind freshIdent #[auxEnumFn, freshSize']
               else
-                mkLetBind freshIdent #[arbitraryFn]
+                mkLetBind freshIdent #[enumFn]
           doElems := doElems.push bindExpr
 
       -- Create an expression `return C x1 ... xn` at the end of the generator, where
@@ -74,58 +73,44 @@ def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command
       let pureExpr ← `(doElem| return $ctorIdent $freshArgIdents*)
       doElems := doElems.push pureExpr
 
-      -- Put the body of the generator together
-      let generatorBody ← liftTermElabM $ mkDoBlock doElems
+      -- Put the body of the enumerator together
+      let enumeratorBody ← liftTermElabM $ mkDoBlock doElems
       if !ctorIsRecursive then
-        nonRecursiveGenerators := nonRecursiveGenerators.push generatorBody
+        nonRecursiveEnumerators := nonRecursiveEnumerators.push enumeratorBody
       else
-        recursiveGenerators := recursiveGenerators.push generatorBody
+        recursiveEnumerators := recursiveEnumerators.push enumeratorBody
 
-  -- Just use the first non-recursive generator as the default generator
-  let defaultGenerator := nonRecursiveGenerators[0]!
+  -- Just use the first non-recursive enumerator as the default enumerator
+  let defaultGenerator := nonRecursiveEnumerators[0]!
 
-  -- Turn each generator into a thunked function and associate each generator with its weight
-  -- (1 for non-recursive generators, `.succ size'` for recursive generators)
-  let thunkedNonRecursiveGenerators ←
-    Array.mapM (fun generatorBody => `($generatorCombinatorsThunkGenFn (fun _ => $generatorBody))) nonRecursiveGenerators
-
-  let mut weightedThunkedNonRecursiveGens := #[]
-  for thunkedGen in thunkedNonRecursiveGenerators do
-    let thunkedGen ← `((1, $thunkedGen))
-    weightedThunkedNonRecursiveGens := weightedThunkedNonRecursiveGens.push thunkedGen
-
-  let mut weightedThunkedRecursiveGens := #[]
-  for recursiveGen in recursiveGenerators do
-    let thunkedWeightedGen ← `(($succIdent $freshSize', $generatorCombinatorsThunkGenFn (fun _ => $recursiveGen)))
-    weightedThunkedRecursiveGens := weightedThunkedRecursiveGens.push thunkedWeightedGen
 
   -- Create the cases for the pattern-match on the size argument
   -- If `size = 0`, pick one of the thunked non-recursive generators
   let mut caseExprs := #[]
-  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
+  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultEnumCombinatorFn $defaultGenerator [$nonRecursiveEnumerators,*])
   caseExprs := caseExprs.push zeroCase
 
-  -- If `size = .succ size'`, pick a generator (it can be non-recursive or recursive)
-  let mut allThunkedWeightedGenerators ← `([$weightedThunkedNonRecursiveGens,*, $weightedThunkedRecursiveGens,*])
-  let succCase ← `(Term.matchAltExpr| | $succIdent $freshSize' => $frequencyFn $defaultGenerator $allThunkedWeightedGenerators)
+  -- If `size = .succ size'`, pick an enumerator (it can be non-recursive or recursive)
+  let mut allEnumerators ← `([$nonRecursiveEnumerators,*, $recursiveEnumerators,*])
+  let succCase ← `(Term.matchAltExpr| | $succIdent $freshSize' => $oneOfWithDefaultEnumCombinatorFn $defaultGenerator $allEnumerators)
   caseExprs := caseExprs.push succCase
 
-  -- Create function argument for the generator size
+  -- Create function argument for the enumerator size
   let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
   let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
 
-  -- Create an instance of the `ArbitrarySized` typeclass
+  -- Create an instance of the `EnumSized` typeclass
   let targetTypeIdent := mkIdent targetTypeName
-  let generatorType ← `($genIdent $targetTypeIdent)
-  `(instance : $arbitrarySizedTypeclass $targetTypeIdent where
-      $unqualifiedArbitrarySizedFn:ident :=
-        let rec $auxArbIdent:ident $sizeParam : $generatorType :=
+  let enumeratorType ← `($enumTypeConstructor $targetTypeIdent)
+  `(instance : $enumSizedTypeclass $targetTypeIdent where
+      $unqualifiedEnumSizedFn:ident :=
+        let rec $auxEnumFn:ident $sizeParam : $enumeratorType :=
           $matchExpr
-      fun $freshSizeIdent => $auxArbIdent $freshSizeIdent)
+      fun $freshSizeIdent => $auxEnumFn $freshSizeIdent)
 
 syntax (name := derive_enum) "#derive_enum" term : command
 
-/-- Command elaborator which derives an instance of the `ArbitrarySized` typeclass -/
+/-- Command elaborator which derives an instance of the `EnumSized` typeclass -/
 @[command_elab derive_enum]
 def elabDeriveEnum : CommandElab := fun stx => do
   match stx with

--- a/Plausible/New/DeriveEnum.lean
+++ b/Plausible/New/DeriveEnum.lean
@@ -2,8 +2,172 @@ import Lean
 import Plausible.IR.Prelude
 import Plausible.New.Idents
 import Plausible.New.TSyntaxCombinators
-import Plausible.New.Arbitrary
+import Plausible.New.Enumerators
 import Plausible.New.Utils
+import Plausible.New.DeriveArbitrary
 
 open Lean Elab Command Meta Term Parser
 open Plausible.IR Idents
+
+/-- Creates an instance of the `ArbitrarySized` typeclass for an inductive type
+    whose name is given by `targetTypeName`.
+
+    (Note: the main logic for determining the structure of the derived generator
+    is contained in this function.) -/
+def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command) := do
+  -- Obtain Lean's `InductiveVal` data structure, which contains metadata about
+  -- the type corresponding to `targetTypeName`
+  let inductiveVal ← getConstInfoInduct targetTypeName
+
+  -- Fetch the ambient local context, which we need to produce user-accessible fresh names
+  let localCtx ← liftTermElabM $ getLCtx
+
+  -- Produce a fresh name for the `size` argument for the lambda
+  -- at the end of the generator function, as well as the `aux_arb` inner helper function
+  let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
+  let freshSize' := mkFreshAccessibleIdent localCtx `size'
+  let auxArbIdent := mkFreshAccessibleIdent localCtx `aux_arb
+
+  let mut nonRecursiveGenerators := #[]
+  let mut recursiveGenerators := #[]
+  for ctorName in inductiveVal.ctors do
+    let ctorIdent := mkIdent ctorName
+
+    let ctorArgNamesTypes ← liftTermElabM $ getCtorArgsNamesAndTypes ctorName
+
+    if ctorArgNamesTypes.isEmpty then
+      -- Constructor is nullary, we can just use a generator of the form `pure ...`
+      let pureGen ← `($pureFn $ctorIdent)
+      nonRecursiveGenerators := nonRecursiveGenerators.push pureGen
+    else
+      -- Produce a fresh name for each of the args to the constructor
+      let ctorArgNames := Prod.fst <$> ctorArgNamesTypes
+      let freshArgIdents := Lean.mkIdent <$> genFreshNames (existingNames := ctorArgNames) (namePrefixes := ctorArgNames)
+
+      let mut doElems := #[]
+
+      -- Determine whether the constructor has any recursive arguments
+      let ctorIsRecursive ← liftTermElabM $ isConstructorRecursive targetTypeName ctorName
+      if !ctorIsRecursive then
+        -- Call `arbitrary` to generate a random value for each of the arguments
+        for freshIdent in freshArgIdents do
+          let bindExpr ← liftTermElabM $ mkLetBind freshIdent #[arbitraryFn]
+          doElems := doElems.push bindExpr
+      else
+        -- For recursive constructors, we need to examine each argument to see which of them require
+        -- recursive calls to the generator
+        let freshArgIdentsTypes := Array.zip freshArgIdents (Prod.snd <$> ctorArgNamesTypes)
+        for (freshIdent, argType) in freshArgIdentsTypes do
+          -- If the argument's type is the same as the target type,
+          -- produce a recursive call to the generator using `aux_arb`,
+          -- otherwise generate a value using `arbitrary`
+          let bindExpr ←
+            liftTermElabM $
+              if argType.getAppFn.constName == targetTypeName then
+                mkLetBind freshIdent #[auxArbFn, freshSize']
+              else
+                mkLetBind freshIdent #[arbitraryFn]
+          doElems := doElems.push bindExpr
+
+      -- Create an expression `return C x1 ... xn` at the end of the generator, where
+      -- `C` is the constructor name and the `xi` are the generated values for the args
+      let pureExpr ← `(doElem| return $ctorIdent $freshArgIdents*)
+      doElems := doElems.push pureExpr
+
+      -- Put the body of the generator together
+      let generatorBody ← liftTermElabM $ mkDoBlock doElems
+      if !ctorIsRecursive then
+        nonRecursiveGenerators := nonRecursiveGenerators.push generatorBody
+      else
+        recursiveGenerators := recursiveGenerators.push generatorBody
+
+  -- Just use the first non-recursive generator as the default generator
+  let defaultGenerator := nonRecursiveGenerators[0]!
+
+  -- Turn each generator into a thunked function and associate each generator with its weight
+  -- (1 for non-recursive generators, `.succ size'` for recursive generators)
+  let thunkedNonRecursiveGenerators ←
+    Array.mapM (fun generatorBody => `($generatorCombinatorsThunkGenFn (fun _ => $generatorBody))) nonRecursiveGenerators
+
+  let mut weightedThunkedNonRecursiveGens := #[]
+  for thunkedGen in thunkedNonRecursiveGenerators do
+    let thunkedGen ← `((1, $thunkedGen))
+    weightedThunkedNonRecursiveGens := weightedThunkedNonRecursiveGens.push thunkedGen
+
+  let mut weightedThunkedRecursiveGens := #[]
+  for recursiveGen in recursiveGenerators do
+    let thunkedWeightedGen ← `(($succIdent $freshSize', $generatorCombinatorsThunkGenFn (fun _ => $recursiveGen)))
+    weightedThunkedRecursiveGens := weightedThunkedRecursiveGens.push thunkedWeightedGen
+
+  -- Create the cases for the pattern-match on the size argument
+  -- If `size = 0`, pick one of the thunked non-recursive generators
+  let mut caseExprs := #[]
+  let zeroCase ← `(Term.matchAltExpr| | $zeroIdent => $oneOfWithDefaultFn $defaultGenerator [$thunkedNonRecursiveGenerators,*])
+  caseExprs := caseExprs.push zeroCase
+
+  -- If `size = .succ size'`, pick a generator (it can be non-recursive or recursive)
+  let mut allThunkedWeightedGenerators ← `([$weightedThunkedNonRecursiveGens,*, $weightedThunkedRecursiveGens,*])
+  let succCase ← `(Term.matchAltExpr| | $succIdent $freshSize' => $frequencyFn $defaultGenerator $allThunkedWeightedGenerators)
+  caseExprs := caseExprs.push succCase
+
+  -- Create function argument for the generator size
+  let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
+  let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
+
+  -- Create an instance of the `ArbitrarySized` typeclass
+  let targetTypeIdent := mkIdent targetTypeName
+  let generatorType ← `($genIdent $targetTypeIdent)
+  `(instance : $arbitrarySizedTypeclass $targetTypeIdent where
+      $unqualifiedArbitrarySizedFn:ident :=
+        let rec $auxArbIdent:ident $sizeParam : $generatorType :=
+          $matchExpr
+      fun $freshSizeIdent => $auxArbIdent $freshSizeIdent)
+
+syntax (name := derive_enum) "#derive_enum" term : command
+
+/-- Command elaborator which derives an instance of the `ArbitrarySized` typeclass -/
+@[command_elab derive_enum]
+def elabDeriveEnum : CommandElab := fun stx => do
+  match stx with
+  | `(#derive_enum $targetTypeTerm:term) => do
+
+    -- TODO: figure out how to support parameterized types
+    let targetTypeIdent ←
+      match targetTypeTerm with
+      | `($tyIdent:ident) => pure tyIdent
+      | _ => throwErrorAt targetTypeTerm "Parameterized types not supported"
+    let targetTypeName := targetTypeIdent.getId
+
+    let isInductiveType ← isInductive targetTypeName
+    if isInductiveType then
+      let typeClassInstance ← mkEnumSizedInstance targetTypeName
+
+      -- Pretty-print the derived enumerator
+      let enumFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
+
+      -- Display the code for the derived typeclass instance to the user
+      -- & prompt the user to accept it in the VS Code side panel
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty enumFormat) (header := "Try this enumerator: ")
+
+      -- Elaborate the typeclass instance and add it to the local context
+      elabCommand typeClassInstance
+    else
+      throwError "Cannot derive Enum instance for non-inductive types"
+
+  | _ => throwUnsupportedSyntax
+
+/-- Deriving handler which produces an instance of the `EnumSized` typeclass for
+    each type specified in `declNames` -/
+def deriveEnumInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
+  if (← declNames.allM isInductive) then
+    for targetTypeName in declNames do
+      let typeClassInstance ← mkEnumSizedInstance targetTypeName
+      elabCommand typeClassInstance
+    return true
+  else
+    throwError "Cannot derive instance of Enum typeclass for non-inductive types"
+    return false
+
+initialize
+  registerDerivingHandler ``Enum deriveEnumInstanceHandler

--- a/Plausible/New/DeriveGenerator.lean
+++ b/Plausible/New/DeriveGenerator.lean
@@ -126,7 +126,7 @@ def mkTopLevelGenerator (baseGenerators : TSyntax `term) (inductiveGenerators : 
     let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
     let freshSize' := mkFreshAccessibleIdent localCtx `size'
     let auxArbIdent := mkFreshAccessibleIdent localCtx `aux_arb
-    let generatorType ← `($optionTIdent $genIdent $targetTypeSyntax)
+    let generatorType ← `($optionTTypeConstructor $genTypeConstructor $targetTypeSyntax)
 
     let inductiveName := inductiveStx.raw.getId
 

--- a/Plausible/New/Enumerators.lean
+++ b/Plausible/New/Enumerators.lean
@@ -123,10 +123,15 @@ instance : Enum Char where
 instance : Enum String where
   enum := List.asString <$> (Enum.enum : Enumerator (List Char))
 
+/-- Produces a `LazyList` containing all `Int`s in-between
+    `lo` and `hi` (inclusive) in ascending order -/
+def lazyListNatRange (lo : Nat) (hi : Nat) : LazyList Nat :=
+  lazySeq .succ lo (.succ (hi - lo))
+
 /-- Enumerates all `Nat`s in-between `lo` and `hi` (inclusive)
     in ascending order -/
 def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
-  fun _ => lazySeq .succ lo (.succ (hi - lo))
+  fun _ => lazyListNatRange lo hi
 
 /-- Produces a `LazyList` containing all `Int`s in-between
     `lo` and `hi` (inclusive) in ascending order -/
@@ -138,3 +143,15 @@ instance : Enum Int where
   enum := fun size =>
     let n := Int.ofNat size
     lazyListIntRange (-n) n
+
+/-- `Enum` instance for `Fin n` where `n > 0`
+  (enumerates all `Nat`s from 0 to `n - 1` inclusive) -/
+instance [NeZero n] : Enum (Fin n) where
+  enum := fun _ =>
+    (Fin.ofNat' n) <$> lazyListNatRange 0 (n - 1)
+
+/-- `Enum` instance for `BitVec w`
+    (uses the `Enum` instance for `Fin (2 ^ w)`, since bitvectors
+    are represented using `Fin (2 ^ w)` under the hood) -/
+instance : Enum (BitVec w) where
+  enum := BitVec.ofFin <$> (Enum.enum : Enumerator (Fin (2 ^ w)))

--- a/Plausible/New/Enumerators.lean
+++ b/Plausible/New/Enumerators.lean
@@ -95,7 +95,7 @@ instance [Enum α] [Enum β] : Enum (α ⊕ β) where
     (Enum.enum n >>= pure ∘ Sum.inl) <|> (Enum.enum n >>= pure ∘ Sum.inr)
 
 /-- Helper function: enumerates lists with a certain `budget` that is
-    divided by 2 during recursive calls -/
+    halved during each recursive calls -/
 def enumListsWithBudget [Enum α] (budget : Nat) : LazyList (List α) :=
   let empty := LazyList.singleton []
   match budget with
@@ -119,7 +119,22 @@ def enumPrintableASCII (size : Nat) : LazyList Char :=
 instance : Enum Char where
   enum := enumPrintableASCII
 
+/-- `Enum` instance for `String`s containing ASCII-printable characters -/
+instance : Enum String where
+  enum := List.asString <$> (Enum.enum : Enumerator (List Char))
+
 /-- Enumerates all `Nat`s in-between `lo` and `hi` (inclusive)
     in ascending order -/
 def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
   fun _ => lazySeq .succ lo (.succ (hi - lo))
+
+/-- Produces a `LazyList` containing all `Int`s in-between
+    `lo` and `hi` (inclusive) in ascending order -/
+def lazyListIntRange (lo : Int) (hi : Int) : LazyList Int :=
+  lazySeq (. + 1) lo (Int.toNat (hi - lo + 1))
+
+/-- `Enum` instance for `Int` (enumerates all `int`s between `-size` and `size` inclusive) -/
+instance : Enum Int where
+  enum := fun size =>
+    let n := Int.ofNat size
+    lazyListIntRange (-n) n

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -11,9 +11,11 @@ def OptionTThunkGenFn : Ident := mkIdent $ Name.mkStr2 "OptionTGen" "thunkGen"
 def OptionTBacktrackFn : Ident := mkIdent $ Name.mkStr2 "OptionTGen" "backtrack"
 def generatorCombinatorsThunkGenFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "thunkGen"
 def frequencyFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "frequency"
-def oneOfWithDefaultFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "oneOfWithDefault"
+def oneOfWithDefaultGenCombinatorFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "oneOfWithDefault"
+def oneOfWithDefaultEnumCombinatorFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "oneOfWithDefault"
 def interpSampleFn : Ident := mkIdent $ Name.mkStr3 "Plausible" "SampleableExt" "interpSample"
 def auxArbFn : Ident := mkIdent $ Name.mkStr1 "aux_arb"
+def auxEnumFn : Ident := mkIdent $ Name.mkStr1 "aux_enum"
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
 
 -- Idents for size arguments to generators
@@ -26,13 +28,17 @@ def failFn : Ident := mkIdent $ Name.mkStr2 "OptionT" "fail"
 -- Idents for typeclasses
 def arbitrarySizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySizedSuchThat"
 def arbitrarySizedTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySized"
+def enumSizedTypeclass : Ident := mkIdent $ Name.mkStr1 "EnumSized"
 
 -- Idents for typeclass functions
 def arbitraryFn : Ident := mkIdent $ Name.mkStr2 "Arbitrary" "arbitrary"
+def enumFn : Ident := mkIdent $ Name.mkStr2 "Enum" "enum"
 def arbitrarySizedFn : Ident := mkIdent $ Name.mkStr2 "ArbitrarySized" "arbitrarySized"
 def unqualifiedArbitrarySizedFn : Ident := mkIdent $ Name.mkStr1 "arbitrarySized"
+def unqualifiedEnumSizedFn : Ident := mkIdent $ Name.mkStr1 "enumSized"
 def arbitrarySTFn : Ident := mkIdent $ Name.mkStr2 "ArbitrarySuchThat" "arbitraryST"
 def unqualifiedArbitrarySizedSTFn : Ident := mkIdent $ Name.mkStr1 "arbitrarySizedST"
+def unqualifiedEnumSizedSTFn : Ident := mkIdent $ Name.mkStr1 "enumSizedST"
 def decOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "decOpt"
 
 
@@ -40,8 +46,9 @@ def decOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "decOpt"
 def natIdent : Ident := mkIdent ``Nat
 def zeroIdent : Ident := mkIdent ``Nat.zero
 def succIdent : Ident := mkIdent ``Nat.succ
-def optionTIdent : Ident := mkIdent ``OptionT
-def genIdent : Ident := mkIdent ``Plausible.Gen
+def optionTTypeConstructor : Ident := mkIdent ``OptionT
+def genTypeConstructor : Ident := mkIdent ``Plausible.Gen
+def enumTypeConstructor : Ident := mkIdent $ Name.mkStr1 "Enumerator"
 
 
 /-- Produces a fresh user-facing & *accessible* identifier with respect to the local context

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -28,9 +28,7 @@ inductive Value where
 
 inductive Foo where
   | FromBitVec : ∀ (n : Nat), BitVec n → String → Foo
-
-
--- #eval (Enum.enum 5 : LazyList (Value))
+  deriving Repr
 
 
 inductive MyList where

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -5,6 +5,7 @@ import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.Arbitrary
 import Plausible.New.ArbitrarySizedSuchThat
+import Plausible.New.EnumeratorCombinators
 import Plausible.New.DeriveEnum
 import Plausible.New.STLC
 
@@ -16,18 +17,20 @@ inductive RGB where
   | Red
   | Green
   | Blue
-  deriving Arbitrary
+  deriving Repr
 
 inductive Value where
   | none
   | bool (b : Bool)
   | int (i : Int)
   | tensor (shape : List Nat) (dtype : String)
-  deriving Arbitrary
+  deriving Repr
 
 inductive Foo where
   | FromBitVec : ∀ (n : Nat), BitVec n → String → Foo
-  deriving Arbitrary
+
+
+-- #eval (Enum.enum 5 : LazyList (Value))
 
 
 inductive MyList where

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -5,6 +5,7 @@ import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.Arbitrary
 import Plausible.New.ArbitrarySizedSuchThat
+import Plausible.New.DeriveEnum
 import Plausible.New.STLC
 
 

--- a/Plausible/New/Utils.lean
+++ b/Plausible/New/Utils.lean
@@ -29,3 +29,18 @@ def replicateM [Monad m] (n : Nat) (action : m α) : m (List α) :=
     let x ← action
     let xs ← replicateM n action
     pure (x :: xs)
+
+/-- `ToMessageData` instance for pretty-printing `ConstructorVal`s -/
+instance : ToMessageData ConstructorVal where
+  toMessageData ctorVal :=
+    let fields := [
+      m!"name := {ctorVal.name}",
+      m!"levelParams := {ctorVal.levelParams}",
+      m!"type := {ctorVal.type}",
+      m!"induct := {ctorVal.induct}",
+      m!"cidx := {ctorVal.cidx}",
+      m!"numParams := {ctorVal.numParams}",
+      m!"numFields := {ctorVal.numFields}",
+      m!"isUnsafe := {ctorVal.isUnsafe}"
+    ]
+    .bracket "{" (.ofList fields) "}"

--- a/Test.lean
+++ b/Test.lean
@@ -5,12 +5,16 @@ Authors: Henrik Böving
 -/
 -- import Test.Tactic
 -- import Test.Testable
+
+-- Tests for `#derive_generator` (`derives ArbitrarySuchThat`)
 import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
 import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
 import Test.DeriveArbitrarySuchThat.DeriveSTLCGenerator
 import Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests
 import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
+
+-- Tests for `deriving Arbitrary`
 import Test.DeriveArbitrary.DeriveTreeGenerator
 import Test.DeriveArbitrary.DeriveSTLCTermTypeGenerators
 import Test.DeriveArbitrary.DeriveNKIValueGenerator
@@ -18,4 +22,15 @@ import Test.DeriveArbitrary.DeriveNKIBinopGenerator
 import Test.DeriveArbitrary.DeriveRegExpGenerator
 import Test.DeriveArbitrary.StructureTest
 import Test.DeriveArbitrary.BitVecStructureTest
+
+-- Tests for instances of `Enum` for simple types
 import Test.Enum.EnumInstancesTest
+
+-- Tests for `deriving Enum`
+import Test.DeriveEnum.DeriveTreeEnumerator
+import Test.DeriveEnum.DeriveSTLCTermTypeEnumerators
+import Test.DeriveEnum.DeriveNKIValueEnumerator
+import Test.DeriveEnum.DeriveNKIBinopEnumerator
+import Test.DeriveEnum.DeriveRegExpEnumerator
+import Test.DeriveEnum.StructureTest
+import Test.DeriveEnum.BitVecStructureTest

--- a/Test/DeriveEnum/BitVecStructureTest.lean
+++ b/Test/DeriveEnum/BitVecStructureTest.lean
@@ -1,0 +1,58 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Test.DeriveArbitrary.BitVecStructureTest
+
+set_option guard_msgs.diff true
+
+deriving instance Enum for DummyInductive
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedDummyInductive -/
+#guard_msgs in
+#synth EnumSized DummyInductive
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum DummyInductive
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized DummyInductive where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator DummyInductive :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let n_0 ← Enum.enum
+            let a_0 ← Enum.enum
+            let a_1 ← Enum.enum
+            return DummyInductive.FromBitVec n_0 a_0 a_1)
+          [do
+            let n_0 ← Enum.enum
+            let a_0 ← Enum.enum
+            let a_1 ← Enum.enum
+            return DummyInductive.FromBitVec n_0 a_0 a_1]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let n_0 ← Enum.enum
+            let a_0 ← Enum.enum
+            let a_1 ← Enum.enum
+            return DummyInductive.FromBitVec n_0 a_0 a_1)
+          [do
+            let n_0 ← Enum.enum
+            let a_0 ← Enum.enum
+            let a_1 ← Enum.enum
+            return DummyInductive.FromBitVec n_0 a_0 a_1, ]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum DummyInductive
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveNKIBinopEnumerator.lean
+++ b/Test/DeriveEnum/DeriveNKIBinopEnumerator.lean
@@ -1,0 +1,46 @@
+import Plausible.New.Arbitrary
+import Plausible.New.DeriveEnum
+import Plausible.New.EnumeratorCombinators
+import Test.DeriveArbitrary.DeriveNKIBinopGenerator
+
+set_option guard_msgs.diff true
+
+deriving instance Enum for BinOp
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedBinOp -/
+#guard_msgs in
+#synth EnumSized BinOp
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum BinOp
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized BinOp where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator BinOp :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault (pure BinOp.land)
+          [pure BinOp.land, pure BinOp.lor, pure BinOp.eq, pure BinOp.ne, pure BinOp.lt, pure BinOp.le, pure BinOp.gt,
+            pure BinOp.ge, pure BinOp.add, pure BinOp.sub, pure BinOp.mul, pure BinOp.div, pure BinOp.mod,
+            pure BinOp.pow, pure BinOp.floor, pure BinOp.lshift, pure BinOp.rshift, pure BinOp.or, pure BinOp.xor,
+            pure BinOp.and]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault (pure BinOp.land)
+          [pure BinOp.land, pure BinOp.lor, pure BinOp.eq, pure BinOp.ne, pure BinOp.lt, pure BinOp.le, pure BinOp.gt,
+            pure BinOp.ge, pure BinOp.add, pure BinOp.sub, pure BinOp.mul, pure BinOp.div, pure BinOp.mod,
+            pure BinOp.pow, pure BinOp.floor, pure BinOp.lshift, pure BinOp.rshift, pure BinOp.or, pure BinOp.xor,
+            pure BinOp.and, ]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum BinOp
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveNKIValueEnumerator.lean
+++ b/Test/DeriveEnum/DeriveNKIValueEnumerator.lean
@@ -1,0 +1,58 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Test.DeriveArbitrary.DeriveNKIValueGenerator
+
+deriving instance Enum for Value
+
+set_option guard_msgs.diff true
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedValue -/
+#guard_msgs in
+#synth EnumSized Value
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum Value
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized Value where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator Value :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault (pure Value.none)
+          [pure Value.none, do
+            let value_0 ← Enum.enum
+            return Value.bool value_0, do
+            let value_0 ← Enum.enum
+            return Value.int value_0, do
+            let value_0 ← Enum.enum
+            return Value.string value_0, pure Value.ellipsis, do
+            let shape_0 ← Enum.enum
+            let dtype_0 ← Enum.enum
+            return Value.tensor shape_0 dtype_0]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault (pure Value.none)
+          [pure Value.none, do
+            let value_0 ← Enum.enum
+            return Value.bool value_0, do
+            let value_0 ← Enum.enum
+            return Value.int value_0, do
+            let value_0 ← Enum.enum
+            return Value.string value_0, pure Value.ellipsis, do
+            let shape_0 ← Enum.enum
+            let dtype_0 ← Enum.enum
+            return Value.tensor shape_0 dtype_0, ]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum Value
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveRegExpEnumerator.lean
+++ b/Test/DeriveEnum/DeriveRegExpEnumerator.lean
@@ -1,0 +1,52 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Test.DeriveArbitrary.DeriveRegExpGenerator
+
+set_option guard_msgs.diff true
+
+deriving instance Enum for RegExp
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedRegExp -/
+#guard_msgs in
+#synth EnumSized RegExp
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum RegExp
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized RegExp where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator RegExp :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault (pure RegExp.EmptySet)
+          [pure RegExp.EmptySet, pure RegExp.EmptyStr, do
+            let a_0 ← Enum.enum
+            return RegExp.Char a_0]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault (pure RegExp.EmptySet)
+          [pure RegExp.EmptySet, pure RegExp.EmptyStr, do
+            let a_0 ← Enum.enum
+            return RegExp.Char a_0, do
+            let a_0 ← aux_enum size'
+            let a_1 ← aux_enum size'
+            return RegExp.App a_0 a_1, do
+            let a_0 ← aux_enum size'
+            let a_1 ← aux_enum size'
+            return RegExp.Union a_0 a_1, do
+            let a_0 ← aux_enum size'
+            return RegExp.Star a_0]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum RegExp
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
+++ b/Test/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
@@ -1,0 +1,90 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Plausible.IR.Examples
+
+set_option guard_msgs.diff true
+
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+deriving instance Enum for type, term
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+-- for both `type` & `term`
+
+/-- info: instEnumSizedType_test -/
+#guard_msgs in
+#synth EnumSized type
+
+/-- info: instEnumSizedTerm_test -/
+#guard_msgs in
+#synth EnumSized term
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum type
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum term
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized type where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator type :=
+      match size with
+      | Nat.zero => EnumeratorCombinators.oneOfWithDefault (pure type.Nat) [pure type.Nat]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault (pure type.Nat)
+          [pure type.Nat, do
+            let a_0 ← aux_enum size'
+            let a_1 ← aux_enum size'
+            return type.Fun a_0 a_1]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum type
+
+/--
+info: Try this enumerator: instance : EnumSized term where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator term :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let a_0 ← Enum.enum
+            return term.Const a_0)
+          [do
+            let a_0 ← Enum.enum
+            return term.Const a_0, do
+            let a_0 ← Enum.enum
+            return term.Var a_0]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let a_0 ← Enum.enum
+            return term.Const a_0)
+          [do
+            let a_0 ← Enum.enum
+            return term.Const a_0, do
+            let a_0 ← Enum.enum
+            return term.Var a_0, do
+            let a_0 ← aux_enum size'
+            let a_1 ← aux_enum size'
+            return term.Add a_0 a_1, do
+            let a_0 ← aux_enum size'
+            let a_1 ← aux_enum size'
+            return term.App a_0 a_1, do
+            let a_0 ← Enum.enum
+            let a_1 ← aux_enum size'
+            return term.Abs a_0 a_1]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum term
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveTreeEnumerator.lean
+++ b/Test/DeriveEnum/DeriveTreeEnumerator.lean
@@ -1,0 +1,43 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Plausible.IR.Examples
+
+set_option guard_msgs.diff true
+
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+deriving instance Enum for Tree
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedTree_test -/
+#guard_msgs in
+#synth EnumSized Tree
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum Tree
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized Tree where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator Tree :=
+      match size with
+      | Nat.zero => EnumeratorCombinators.oneOfWithDefault (pure Tree.Leaf) [pure Tree.Leaf]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault (pure Tree.Leaf)
+          [pure Tree.Leaf, do
+            let a_0 ← Enum.enum
+            let a_1 ← aux_enum size'
+            let a_2 ← aux_enum size'
+            return Tree.Node a_0 a_1 a_2]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum Tree
+
+end CommandElaboratorTest

--- a/Test/DeriveEnum/StructureTest.lean
+++ b/Test/DeriveEnum/StructureTest.lean
@@ -1,0 +1,58 @@
+import Plausible.New.Enumerators
+import Plausible.New.EnumeratorCombinators
+import Plausible.New.DeriveEnum
+import Test.DeriveArbitrary.StructureTest
+
+set_option guard_msgs.diff true
+
+deriving instance Enum for Foo
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
+
+/-- info: instEnumSizedFoo -/
+#guard_msgs in
+#synth EnumSized Foo
+
+/-- info: instEnumOfEnumSized -/
+#guard_msgs in
+#synth Enum Foo
+
+-- We test the command elaborator frontend in a separate namespace to
+-- avoid overlapping typeclass instances for the same type
+namespace CommandElaboratorTest
+
+/--
+info: Try this enumerator: instance : EnumSized Foo where
+  enumSized :=
+    let rec aux_enum (size : Nat) : Enumerator Foo :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let stringField_0 ← Enum.enum
+            let boolField_0 ← Enum.enum
+            let natField_0 ← Enum.enum
+            return Foo.mk stringField_0 boolField_0 natField_0)
+          [do
+            let stringField_0 ← Enum.enum
+            let boolField_0 ← Enum.enum
+            let natField_0 ← Enum.enum
+            return Foo.mk stringField_0 boolField_0 natField_0]
+      | Nat.succ size' =>
+        EnumeratorCombinators.oneOfWithDefault
+          (do
+            let stringField_0 ← Enum.enum
+            let boolField_0 ← Enum.enum
+            let natField_0 ← Enum.enum
+            return Foo.mk stringField_0 boolField_0 natField_0)
+          [do
+            let stringField_0 ← Enum.enum
+            let boolField_0 ← Enum.enum
+            let natField_0 ← Enum.enum
+            return Foo.mk stringField_0 boolField_0 natField_0, ]
+    fun size => aux_enum size
+-/
+#guard_msgs(info, drop warning) in
+#derive_enum Foo
+
+end CommandElaboratorTest

--- a/Test/Enum/EnumInstancesTest.lean
+++ b/Test/Enum/EnumInstancesTest.lean
@@ -8,6 +8,15 @@ import Plausible.New.Enumerators
 #guard_msgs in
 #eval (Enum.enum 7 : LazyList Nat)
 
+/-- info: [0, 1, 2, 3, 4] -/
+#guard_msgs in
+#eval (Enum.enum 5 : LazyList (Fin 5))
+
+/-- info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] -/
+#guard_msgs in
+#eval (Enum.enum 10 : LazyList (Fin 10))
+
+
 /-- info: [false, true] -/
 #guard_msgs in
 #eval (Enum.enum 10 : LazyList Bool)


### PR DESCRIPTION
(This PR is very similar to https://github.com/ngernest/chamelean_wip/pull/6, since it involves analogous metaprogramming infrastructure for deriving typeclass instances, and also because the structure of derived unconstrained generators/enumerators resemble each other.)

This PR implements a deriving handler frontend for `Enum`.
Users can write `deriving Enum` after an inductive type definition like so:

```lean
inductive Tree where
  ...
  deriving Enum 
```

Alternatively, users can also write `deriving instance Enum for T1, ..., Tn` as a top-level command
to derive `Enum` instances for types `T1, ..., Tn` simultaneously.
