### PR TITLE
Derive Checkers for Inductively-Defined Propositions

### DIFF
--- a/Plausible/IR/Constructor.lean
+++ b/Plausible/IR/Constructor.lean
@@ -127,12 +127,18 @@ instance : ToMessageData HandlerInfo where
 -- Pretty printer for `SubGeneratorInfo`
 instance : ToMessageData SubGeneratorInfo where
   toMessageData subGen : MessageData :=
-    toMessageData subGen.toHandlerInfo ++ m!"generatorSort := {repr subGen.generatorSort}"
+    .joinSep [
+      toMessageData subGen.toHandlerInfo,
+      m!"generatorSort := {repr subGen.generatorSort}"
+    ] "¬"
 
 -- Pretty printer for `SubCheckerInfo`
 instance : ToMessageData SubCheckerInfo where
   toMessageData subChecker : MessageData :=
-    toMessageData subChecker.toHandlerInfo ++ m!"checkerSort := {repr subChecker.checkerSort}"
+    .joinSep [
+      toMessageData subChecker.toHandlerInfo,
+      m!"checkerSort := {repr subChecker.checkerSort}"
+    ] "\n"
 
 
 /-- Converts an array of `Action`s into a `GroupedActions` -/
@@ -304,17 +310,17 @@ def backtrackElem_return_checker (backtrackElem : HandlerInfo) (indentation : St
 /-- Assembles all the components of a sub-checker (a `BacktrackElem`) together, returning a string
     containing the Lean code for the sub-checker -/
 def backtrack_elem_toString_checker (subChecker: SubCheckerInfo) (monad: String :="IO") : MetaM String := do
-  let backtrackElem := subChecker.toHandlerInfo
+  let handlerInfo := subChecker.toHandlerInfo
 
   IO.println "********************"
   IO.println s!"entered `backtrack_elem_toString_checker`:"
-  IO.println (← MessageData.toString (toMessageData backtrackElem))
+  IO.println (← MessageData.toString (toMessageData handlerInfo))
 
   let mut out := ""
-  let matchblock ← backtrackElem_match_block backtrackElem
-  let (genblock, iden) ← backtrackElem_gen_block backtrackElem monad
-  let (checkIRblock, vars) ← backtrackElem_gen_check_IR_block backtrackElem iden monad
-  let returnblock ← backtrackElem_return_checker backtrackElem iden vars monad
+  let matchblock ← backtrackElem_match_block handlerInfo
+  let (genblock, iden) ← backtrackElem_gen_block handlerInfo monad
+  let (checkIRblock, vars) ← backtrackElem_gen_check_IR_block handlerInfo iden monad
+  let returnblock ← backtrackElem_return_checker handlerInfo iden vars monad
   out := out ++ matchblock
   if genblock.length > 0 ∧ out.length > 0 then
     out := out ++ "\n"

--- a/Plausible/IR/GCCall.lean
+++ b/Plausible/IR/GCCall.lean
@@ -183,7 +183,8 @@ inductive Action where
   | checkInductive (hyp : Expr)
 
   /-- The hypothesis `hyp` is not an inductive relation, but a function that returns
-      `Prop`, so we invoke a checker that determines whether the `Prop` is true -/
+      `Prop`, so we invoke a checker that determines whether the `Prop` is true
+      (this checker is provided via the `DecOpt` instance for the `Prop`) -/
   | checkNonInductive (hyp : Expr)
 
   /-- Generate an input at the given position `pos` for an inductive relation

--- a/Plausible/IR/GCCall.lean
+++ b/Plausible/IR/GCCall.lean
@@ -433,10 +433,6 @@ def elabCheckerCall : CommandElab := fun stx => do
   | _ => throwError "Invalid syntax"
 
 
--- #get_checker_call typing
--- #get_checker_call balanced
--- #get_checker_call bst
-
 syntax (name := geGenCall) "#get_producer_call" term "for_arg" num : command
 
 @[command_elab geGenCall]
@@ -456,9 +452,5 @@ def elabGenCall : CommandElab := fun stx => do
           IO.println (← Actions_toRawCode Action)
   | _ => throwError "Invalid syntax"
 
-
--- #get_producer_call typing for_arg 2
--- #get_producer_call balanced for_arg 1
--- #get_producer_call bst for_arg 2
 
 end Plausible.IR

--- a/Plausible/IR/GCCall.lean
+++ b/Plausible/IR/GCCall.lean
@@ -314,14 +314,12 @@ def Actions_for_hypotheses (ctor : InductiveConstructor) (fvars : Array FVarId) 
 
         let argToGenerate := hyp.getAppArgs[uninitializedArgIdx]!
 
-
         initializedFVars := Array.appendUniqueElements initializedFVars uninitializedFVars
 
         let generationStyle :=
           if hypothesisRecursivelyCallsCurrentInductive hyp ctor
           then .RecursiveCall
           else .TypeClassResolution
-
 
         if argToGenerate.isFVar then
           let fvarToGenerate := argToGenerate.fvarId!

--- a/Plausible/New/Arbitrary.lean
+++ b/Plausible/New/Arbitrary.lean
@@ -35,7 +35,7 @@ instance [SampleableExt α] : Arbitrary α where
   arbitrary := SampleableExt.interp <$> SampleableExt.sample
 
 /-- Samples from the generator associated with the `Arbitrary` instance for a type,
-    using `size` as the size parameter for the genreator.
+    using `size` as the size parameter for the generator.
     To invoke this function, you will need to specify what type `α` is,
     for example by doing `runArbitrary (α := Nat) 10`. -/
 def runArbitrary {α} [Arbitrary α] (size : Nat) : IO α :=

--- a/Plausible/New/Chamelean.lean
+++ b/Plausible/New/Chamelean.lean
@@ -1,5 +1,6 @@
 import Plausible.New.DeriveChecker
 import Plausible.New.SubGenerators
+import Plausible.New.SubCheckers
 import Plausible.New.DeriveGenerator
 import Plausible.New.Tests
 import Plausible.New.OptionTGen

--- a/Plausible/New/DecOpt.lean
+++ b/Plausible/New/DecOpt.lean
@@ -10,7 +10,6 @@
        sense that if they ever return `some b` for
        some fuel, they will also do so for higher
        fuel values.
-
 -/
 class DecOpt (P : Prop) where
   decOpt : Nat → Option Bool
@@ -18,11 +17,7 @@ class DecOpt (P : Prop) where
 /-- All `Prop`s that have a `Decidable` instance (this includes `DecidableEq`)
     can be automatically given a `DecOpt` instance -/
 instance [Decidable P] : DecOpt P where
-  decOpt := fun _ =>
-    if decide P then
-      some true
-    else
-      some false
+  decOpt := fun _ => some (decide P)
 
 
 ----------------------------------------------------------------------------------
@@ -33,7 +28,8 @@ instance [Decidable P] : DecOpt P where
 /-- `checkerBacktrack` takes a list of checker handlers and returns:
     - `some true` if *any* handler does so
     - `some false` if *all* handlers do so
-    - `none` otherwise -/
+    - `none` otherwise
+    (see section 2 of "Computing Correctly with Inductive Relations") -/
 def checkerBacktrack (checkers : List (Unit → Option Bool)) : Option Bool :=
   let rec aux (l : List (Unit → Option Bool)) (b : Bool) : Option Bool :=
     match l with
@@ -44,3 +40,10 @@ def checkerBacktrack (checkers : List (Unit → Option Bool)) : Option Bool :=
       | none => aux cs true
     | [] => if b then none else some false
   aux checkers false
+
+/-- Conjunction lifted to work over `Option Bool`
+    (corresponds to the `.&&` infix operator in section 2 of "Computing Correctly with Inductive Relations") -/
+def andBind (a : Option Bool) (b : Option Bool) : Option Bool :=
+  match a with
+  | some true => b
+  | _ => a

--- a/Plausible/New/DecOpt.lean
+++ b/Plausible/New/DecOpt.lean
@@ -25,6 +25,8 @@ instance [Decidable P] : DecOpt P where
 -- https://github.com/QuickChick/QuickChick/blob/master/src/Decidability.v
 ----------------------------------------------------------------------------------
 
+namespace DecOpt
+
 /-- `checkerBacktrack` takes a list of checker handlers and returns:
     - `some true` if *any* handler does so
     - `some false` if *all* handlers do so
@@ -47,3 +49,5 @@ def andBind (a : Option Bool) (b : Option Bool) : Option Bool :=
   match a with
   | some true => b
   | _ => a
+
+end DecOpt

--- a/Plausible/New/DecOpt.lean
+++ b/Plausible/New/DecOpt.lean
@@ -45,9 +45,14 @@ def checkerBacktrack (checkers : List (Unit → Option Bool)) : Option Bool :=
 
 /-- Conjunction lifted to work over `Option Bool`
     (corresponds to the `.&&` infix operator in section 2 of "Computing Correctly with Inductive Relations") -/
-def andBind (a : Option Bool) (b : Option Bool) : Option Bool :=
+def andOpt (a : Option Bool) (b : Option Bool) : Option Bool :=
   match a with
   | some true => b
   | _ => a
+
+/-- Folds an optional conjunction operation `andOpt` over a list of `Option Bool`s,
+    returning the resultant `Option Bool` -/
+def andOptList (bs : List (Option Bool)) : Option Bool :=
+  List.foldl andOpt (some true) bs
 
 end DecOpt

--- a/Plausible/New/DecOpt.lean
+++ b/Plausible/New/DecOpt.lean
@@ -4,7 +4,7 @@
 
 /-- The `DecOpt` class encodes partial decidability:
      - It takes a `nat` argument as fuel
-     - It returns `none`, if it can't decide.
+     - It returns `none`, if it can't decide (e.g. because it runs out of fuel)
      - It returns `some true/some false` if it can.
      - These are supposed to be monotonic, in the
        sense that if they ever return `some b` for

--- a/Plausible/New/DeriveArbitrary.lean
+++ b/Plausible/New/DeriveArbitrary.lean
@@ -41,7 +41,7 @@ def getCtorArgsNamesAndTypes (ctorName : Name) : MetaM (Array (Name × Expr)) :=
 
     return argNamesAndTypes
 
-/-- Creates an instance of the `ArbitrarySized` typeclass for an inductive type
+/-- Produces an instance of the `ArbitrarySized` typeclass for an inductive type
     whose name is given by `targetTypeName`.
 
     (Note: the main logic for determining the structure of the derived generator

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -2,12 +2,77 @@ import Lean
 import Plausible.IR.Prelude
 import Plausible.New.DeriveGenerator
 import Plausible.New.SubCheckers
+import Plausible.New.Idents
 
 open Lean Elab Command Meta Term Parser
+open Idents
 open Plausible.IR
 
+/-- Produces an instance of the `DecOpt` typeclass containing the definition for the top-level derived checker.
+    The arguments to this function are:
+    - a list of `baseCheckers` (each represented as a Lean term), to be invoked when `size == 0`
+    - a list of `inductiveCheckers`, to be invoked when `size > 0`
+    - the name of the inductive relation (`inductiveStx`)
+    - the arguments (`args`) to the inductive relation -/
+def mkTopLevelChecker (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax `term)
+  (inductiveStx : TSyntax `term) (args : TSyntaxArray `term) : CommandElabM (TSyntax `command) := do
+  -- Fetch the ambient local context, which we need to produce user-accessible fresh names
+  let localCtx ← liftTermElabM $ getLCtx
+
+  -- Produce a fresh name for the `size` argument for the lambda
+  -- at the end of the checker function, as well as the `aux_dec` inner helper function
+  let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
+  let freshSize' := mkFreshAccessibleIdent localCtx `size'
+  let auxDecIdent := mkFreshAccessibleIdent localCtx `aux_dec
+  let checkerType ← `($optionTypeConstructor $boolIdent)
+
+  let inductiveName := inductiveStx.raw.getId
+
+  -- Create the cases for the pattern-match on the size argument
+  let mut caseExprs := #[]
+  let zeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $checkerBacktrackFn $baseCheckers)
+  caseExprs := caseExprs.push zeroCase
+
+  let succCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshSize' => $checkerBacktrackFn $inductiveCheckers)
+  caseExprs := caseExprs.push succCase
+
+  -- Create function arguments for the checker's `size` & `initSize` parameters
+  -- (former is the generator size, latter is the size argument with which to invoke other auxiliary generators/checkers)
+  let initSizeParam ← `(Term.letIdBinder| ($initSizeIdent : $natIdent))
+  let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
+  let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
+
+  -- Add parameters for each argument to the inductive relation
+  let paramInfo ← analyzeInductiveArgs inductiveName args
+
+  -- Inner params are for the inner `aux_dec` function
+  let mut innerParams := #[]
+  innerParams := innerParams.push initSizeParam
+  innerParams := innerParams.push sizeParam
+
+  -- Outer params are for the top-level lambda function which invokes `aux_arb`
+  let mut outerParams := #[]
+  for (paramName, paramType) in paramInfo do
+    let outerParamIdent := mkIdent paramName
+    outerParams := outerParams.push outerParamIdent
+
+    -- Each parameter to the inner `aux_arb` function needs to be a fresh name
+    -- (so that if we pattern match on the parameter, we avoid pattern variables from shadowing it)
+    let innerParamIdent := mkIdent $ genFreshName (Array.map Prod.fst paramInfo) paramName
+
+    let innerParam ← `(Term.letIdBinder| ($innerParamIdent : $paramType))
+    innerParams := innerParams.push innerParam
+
+  -- Produces an instance of the `DecOpt` typeclass containing the definition for the derived generator
+  `(instance : $decOptTypeclass (inductiveStx $args*) where
+      $unqualifiedDecOptFn:ident :=
+        let rec $auxDecIdent:ident $innerParams* : $checkerType :=
+          $matchExpr
+        fun $freshSizeIdent => $auxDecIdent $freshSizeIdent $freshSizeIdent $outerParams*)
+
+
 ----------------------------------------------------------------------
--- Command elaborator for deriving checkers
+-- Command elaborator driver
 -----------------------------------------------------------------------
 
 syntax (name := derive_checker) "#derive_checker" "(" term ")" : command
@@ -36,8 +101,8 @@ def elabDeriveChecker : CommandElab := fun stx => do
     let baseCheckerInfos := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
     let inductiveCheckerInfos := allSubCheckerInfos
 
-    let _ ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) baseCheckerInfos
-    let _ ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) inductiveCheckerInfos
+    let baseCheckers ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) baseCheckerInfos
+    let inductiveCheckers ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) inductiveCheckerInfos
 
   | _ => throwUnsupportedSyntax
 
@@ -51,7 +116,7 @@ def elabDeriveChecker : CommandElab := fun stx => do
 
 /-
 
-let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
+let rec aux_arb (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
   match size with
   | .zero =>
     DecOpt.checkerBacktrack [
@@ -72,9 +137,9 @@ let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : 
         | .Leaf => some false
         | .Node x l r =>
           DecOpt.andOptList [
-            DecOpt.decOpt (lo_0 < x && x < hi_0) init_size,
-            aux_arb init_size size' lo_0 x l,
-            aux_arb init_size size' x hi_0 r
+            DecOpt.decOpt (lo_0 < x && x < hi_0) initSize,
+            aux_arb initSize size' lo_0 x l,
+            aux_arb initSize size' x hi_0 r
           ]
     ]
 

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -102,8 +102,8 @@ def elabDeriveChecker : CommandElab := fun stx => do
     let baseCheckerInfos := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
     let inductiveCheckerInfos := allSubCheckerInfos
 
-    let baseCheckers ← liftTermElabM $ mkSubCheckers baseCheckerInfos
-    let inductiveCheckers ← liftTermElabM $ mkSubCheckers inductiveCheckerInfos
+    let baseCheckers ← liftTermElabM $ mkThunkedSubCheckers baseCheckerInfos
+    let inductiveCheckers ← liftTermElabM $ mkThunkedSubCheckers inductiveCheckerInfos
 
     -- Produce an instance of the `DecOpt` typeclass
     let typeclassInstance ← mkTopLevelChecker baseCheckers inductiveCheckers inductiveName args

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -49,6 +49,8 @@ def elabDeriveChecker : CommandElab := fun stx => do
 
 -- #derive_checker (bst lo hi t)
 -- #derive_checker (balanced n t)
+-- #derive_checker (lookup Γ x τ)
+-- #derive_checker (typing Γ e τ)
 
 /-
 

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -71,6 +71,35 @@ def mkTopLevelChecker (baseCheckers : TSyntax `term) (inductiveCheckers : TSynta
           $matchExpr
         fun $freshSizeIdent => $auxDecIdent $freshSizeIdent $freshSizeIdent $outerParams*)
 
+/-- Produces an instance of the `DecOpt` typeclass for an inductively-defined proposition type
+    represented by `indProp` (Note: the main logic for determining the structure of the derived checker.
+    is contained in this function.) -/
+def mkDecOptInstance (indProp : TSyntax `term) : CommandElabM (TSyntax `command) := do
+  -- Parse the for an application of the inductive relation
+  let (inductiveName, args) ← deconstructInductiveApplication indProp
+
+  -- Elaborate the name of the inductive relation and the type
+  -- of the value to be generated
+  let inductiveExpr ← liftTermElabM $ elabTerm inductiveName none
+
+  let argNameStrings := convertIdentsToStrings args
+
+  -- Create an auxiliary `SubGeneratorInfo` structure that
+  -- stores the metadata for each derived sub-generator
+  let allSubCheckerInfos ← liftTermElabM $ getSubCheckerInfos inductiveExpr argNameStrings
+
+  -- Every generator is an inductive generator
+  -- (they can all be invoked in the inductive case of the top-level generator),
+  -- but only certain generators qualify as `BaseGenerator`s
+  let baseCheckerInfos := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
+  let inductiveCheckerInfos := allSubCheckerInfos
+
+  let baseCheckers ← liftTermElabM $ mkThunkedSubCheckers baseCheckerInfos
+  let inductiveCheckers ← liftTermElabM $ mkThunkedSubCheckers inductiveCheckerInfos
+
+  -- Produce an instance of the `DecOpt` typeclass
+  mkTopLevelChecker baseCheckers inductiveCheckers inductiveName args
+
 
 ----------------------------------------------------------------------
 -- Command elaborator driver
@@ -82,31 +111,10 @@ syntax (name := derive_checker) "#derive_checker" "(" term ")" : command
 @[command_elab derive_checker]
 def elabDeriveChecker : CommandElab := fun stx => do
   match stx with
-  | `(#derive_checker ( $body:term )) => do
-    -- Parse the body of the lambda for an application of the inductive relation
-    let (inductiveName, args) ← deconstructInductiveApplication body
+  | `(#derive_checker ( $indProp:term )) => do
 
-    -- Elaborate the name of the inductive relation and the type
-    -- of the value to be generated
-    let inductiveExpr ← liftTermElabM $ elabTerm inductiveName none
-
-    let argNameStrings := convertIdentsToStrings args
-
-    -- Create an auxiliary `SubGeneratorInfo` structure that
-    -- stores the metadata for each derived sub-generator
-    let allSubCheckerInfos ← liftTermElabM $ getSubCheckerInfos inductiveExpr argNameStrings
-
-    -- Every generator is an inductive generator
-    -- (they can all be invoked in the inductive case of the top-level generator),
-    -- but only certain generators qualify as `BaseGenerator`s
-    let baseCheckerInfos := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
-    let inductiveCheckerInfos := allSubCheckerInfos
-
-    let baseCheckers ← liftTermElabM $ mkThunkedSubCheckers baseCheckerInfos
-    let inductiveCheckers ← liftTermElabM $ mkThunkedSubCheckers inductiveCheckerInfos
-
-    -- Produce an instance of the `DecOpt` typeclass
-    let typeclassInstance ← mkTopLevelChecker baseCheckers inductiveCheckers inductiveName args
+    -- Produce an instance of the `DecOpt` typeclass corresponding to the inductive proposition `indProp`
+    let typeclassInstance ← mkDecOptInstance indProp
 
     -- Pretty-print the derived checker
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeclassInstance)
@@ -121,41 +129,8 @@ def elabDeriveChecker : CommandElab := fun stx => do
 
   | _ => throwUnsupportedSyntax
 
--- TODO: see if we can implement a deriving handler to support
--- `deriving instance DecOpt for (bst lo hi t)` syntax
 
 -- #derive_checker (bst lo hi t)
 -- #derive_checker (balanced n t)
 -- #derive_checker (lookup Γ x τ)
 -- #derive_checker (typing Γ e τ)
-
-/-
-
-let rec aux_arb (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
-  match size with
-  | .zero =>
-    DecOpt.checkerBacktrack [
-      fun _ =>
-        match t_0 with
-        | .Leaf => some true
-        | .Node _ _ _ => some false,
-      fun _ => none
-    ]
-  | .succ size' =>
-    DecOpt.checkerBacktrack [
-      fun _ =>
-        match t_0 with
-        | .Leaf => some true
-        | .Node _ _ _ => some false,
-      fun _ =>
-        match t_0 with
-        | .Leaf => some false
-        | .Node x l r =>
-          DecOpt.andOptList [
-            DecOpt.decOpt (lo_0 < x && x < hi_0) initSize,
-            aux_arb initSize size' lo_0 x l,
-            aux_arb initSize size' x hi_0 r
-          ]
-    ]
-
--/

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -1,6 +1,7 @@
 import Lean
 import Plausible.IR.Prelude
 import Plausible.New.DeriveGenerator
+import Plausible.New.SubCheckers
 
 open Lean Elab Command Meta Term Parser
 open Plausible.IR
@@ -19,8 +20,6 @@ def elabDeriveChecker : CommandElab := fun stx => do
     -- Parse the body of the lambda for an application of the inductive relation
     let (inductiveName, args) ← deconstructInductiveApplication body
 
-    logInfo m!"inductiveName = {inductiveName}, args = {args}"
-
     -- Elaborate the name of the inductive relation and the type
     -- of the value to be generated
     let inductiveExpr ← liftTermElabM $ elabTerm inductiveName none
@@ -31,14 +30,56 @@ def elabDeriveChecker : CommandElab := fun stx => do
     -- stores the metadata for each derived sub-generator
     let allSubCheckerInfos ← liftTermElabM $ getSubCheckerInfos inductiveExpr argNameStrings
 
+    -- for sc in allSubCheckerInfos do
+    --   logInfo m!"subChecker = {sc}"
+
     -- Every generator is an inductive generator
     -- (they can all be invoked in the inductive case of the top-level generator),
     -- but only certain generators qualify as `BaseGenerator`s
-    let _baseCheckerInfo := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
-    let _inductiveCheckerInfo := allSubCheckerInfos
+    let baseCheckerInfos := Array.filter (fun checker => checker.checkerSort == .BaseChecker) allSubCheckerInfos
+    let inductiveCheckerInfos := allSubCheckerInfos
+
+    let _ ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) baseCheckerInfos
+
 
 
 
 
 
   | _ => throwUnsupportedSyntax
+
+-- TODO: see if we can implement a deriving handler to support
+-- `deriving instance DecOpt for (bst lo hi t)` syntax
+
+-- #derive_checker (bst lo hi t)
+
+/-
+
+let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
+  match size with
+  | .zero =>
+    DecOpt.checkerBacktrack [
+      fun _ =>
+        match t_0 with
+        | .Leaf => some true
+        | .Node _ _ _ => some false,
+      fun _ => none
+    ]
+  | .succ size' =>
+    DecOpt.checkerBacktrack [
+      fun _ =>
+        match t_0 with
+        | .Leaf => some true
+        | .Node _ _ _ => some false,
+      fun _ =>
+        match t_0 with
+        | .Leaf => some false
+        | .Node x l r =>
+          DecOpt.andOptList [
+            DecOpt.decOpt (lo_0 < x && x < hi_0) init_size,
+            aux_arb init_size size' lo_0 x l,
+            aux_arb init_size size' x hi_0 r
+          ]
+    ]
+
+-/

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -122,7 +122,7 @@ def elabDeriveChecker : CommandElab := fun stx => do
     -- Display the code for the derived checker to the user
     -- & prompt the user to accept it in the VS Code side panel
     liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this generator: ")
+      (Format.pretty genFormat) (header := "Try this checker: ")
 
     -- Elaborate the typeclass instance and add it to the local context
     elabCommand typeclassInstance

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -40,11 +40,7 @@ def elabDeriveChecker : CommandElab := fun stx => do
     let inductiveCheckerInfos := allSubCheckerInfos
 
     let _ ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) baseCheckerInfos
-
-
-
-
-
+    let _ ← Array.mapM (fun chk => liftTermElabM $ mkSubChecker chk) inductiveCheckerInfos
 
   | _ => throwUnsupportedSyntax
 
@@ -52,6 +48,7 @@ def elabDeriveChecker : CommandElab := fun stx => do
 -- `deriving instance DecOpt for (bst lo hi t)` syntax
 
 -- #derive_checker (bst lo hi t)
+-- #derive_checker (balanced n t)
 
 /-
 

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -30,9 +30,6 @@ def elabDeriveChecker : CommandElab := fun stx => do
     -- stores the metadata for each derived sub-generator
     let allSubCheckerInfos ← liftTermElabM $ getSubCheckerInfos inductiveExpr argNameStrings
 
-    -- for sc in allSubCheckerInfos do
-    --   logInfo m!"subChecker = {sc}"
-
     -- Every generator is an inductive generator
     -- (they can all be invoked in the inductive case of the top-level generator),
     -- but only certain generators qualify as `BaseGenerator`s
@@ -47,7 +44,7 @@ def elabDeriveChecker : CommandElab := fun stx => do
 -- TODO: see if we can implement a deriving handler to support
 -- `deriving instance DecOpt for (bst lo hi t)` syntax
 
--- #derive_checker (bst lo hi t)
+#derive_checker (bst lo hi t)
 -- #derive_checker (balanced n t)
 -- #derive_checker (lookup Γ x τ)
 -- #derive_checker (typing Γ e τ)

--- a/Plausible/New/EnumeratorCombinators.lean
+++ b/Plausible/New/EnumeratorCombinators.lean
@@ -61,7 +61,7 @@ def lazyListBacktrackOpt (l : LazyList (Option α)) (f : α → Option Bool) (an
       | .none => lazyListBacktrackOpt xs.get f true
     | .none => lazyListBacktrackOpt xs.get f true
 
-/-- Iterates through all the results of the enumerator `e`, applying the checker `f` to them
+/-- Iterates through all the results of the enumerator `e`, applies the checker `f` to them,
     and returns the resultant `Option Bool`
     - This corresponds to `bind_EC` in the Computing Correctly paper (section 4) -/
 def enumeratingOpt (e : OptionT Enumerator α) (f : α → Option Bool) (size : Nat) : Option Bool :=

--- a/Plausible/New/Enumerators.lean
+++ b/Plausible/New/Enumerators.lean
@@ -72,6 +72,14 @@ instance [EnumSized α] : Enum α where
 instance [EnumSizedSuchThat α P] : EnumSuchThat α P where
   enumST := sizedEnum (EnumSizedSuchThat.enumSizedST P)
 
+/-- Returns the list of elements produced by the enumerator
+    associated with the `Enum` instance for a type,
+    using `size` as the size parameter for the enumerator.
+    To invoke this function, you will need to specify what type `α` is,
+    for example by doing `runEnum (α := Nat) 10`. -/
+def runEnum [Enum α] (size : Nat) : IO (List α) :=
+  return (LazyList.toList $ Enum.enum size)
+
 -- Some simple `Enum` instances
 
 /-- `Enum` instance for `Bool` -/

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -24,7 +24,12 @@ def auxEnumFn : Ident := mkIdent $ Name.mkStr1 "aux_enum"
 /-- Ident for the inner `aux_dec` function that appears in derived checkers -/
 def auxDecFn : Ident := mkIdent $ Name.mkStr1 "aux_dec"
 
+/-- Ident for the `DecOpt.andOptList` checker combinator (see `DecOpt.lean`) -/
 def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
+
+/-- Ident for the `DecOpt.checkerBacktrack` checker combinator (see `DecOpt.lean`) -/
+def checkerBacktrackFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "checkerBacktrack"
+
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
 def someFn : Ident := mkIdent ``some
 def trueIdent : Ident := mkIdent ``true
@@ -41,6 +46,7 @@ def failFn : Ident := mkIdent $ Name.mkStr2 "OptionT" "fail"
 def arbitrarySizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySizedSuchThat"
 def arbitrarySizedTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySized"
 def enumSizedTypeclass : Ident := mkIdent $ Name.mkStr1 "EnumSized"
+def decOptTypeclass : Ident := mkIdent $ Name.mkStr1 "DecOpt"
 
 -- Idents for typeclass functions
 def arbitraryFn : Ident := mkIdent $ Name.mkStr2 "Arbitrary" "arbitrary"
@@ -51,13 +57,16 @@ def unqualifiedEnumSizedFn : Ident := mkIdent $ Name.mkStr1 "enumSized"
 def arbitrarySTFn : Ident := mkIdent $ Name.mkStr2 "ArbitrarySuchThat" "arbitraryST"
 def unqualifiedArbitrarySizedSTFn : Ident := mkIdent $ Name.mkStr1 "arbitrarySizedST"
 def unqualifiedEnumSizedSTFn : Ident := mkIdent $ Name.mkStr1 "enumSizedST"
+def unqualifiedDecOptFn : Ident := mkIdent $ Name.mkStr1 "decOpt"
 def decOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "decOpt"
 
 
--- Idents for commonly-used types / constructors
+-- Idents for commonly-used types / constructors / type constructors
+def boolIdent : Ident := mkIdent ``Bool
 def natIdent : Ident := mkIdent ``Nat
 def zeroIdent : Ident := mkIdent ``Nat.zero
 def succIdent : Ident := mkIdent ``Nat.succ
+def optionTypeConstructor : Ident := mkIdent `Option
 def optionTTypeConstructor : Ident := mkIdent ``OptionT
 def genTypeConstructor : Ident := mkIdent ``Plausible.Gen
 def enumTypeConstructor : Ident := mkIdent $ Name.mkStr1 "Enumerator"

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -16,8 +16,10 @@ def oneOfWithDefaultEnumCombinatorFn : Ident := mkIdent $ Name.mkStr2 "Enumerato
 def interpSampleFn : Ident := mkIdent $ Name.mkStr3 "Plausible" "SampleableExt" "interpSample"
 def auxArbFn : Ident := mkIdent $ Name.mkStr1 "aux_arb"
 def auxEnumFn : Ident := mkIdent $ Name.mkStr1 "aux_enum"
+def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
-def someFn : Ident := mkIdent $ Name.mkStr1 "some"
+def someFn : Ident := mkIdent ``some
+def trueIdent : Ident := mkIdent ``true
 def falseIdent : Ident := mkIdent ``false
 
 -- Idents for size arguments to generators

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -14,8 +14,16 @@ def frequencyFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "frequen
 def oneOfWithDefaultGenCombinatorFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "oneOfWithDefault"
 def oneOfWithDefaultEnumCombinatorFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "oneOfWithDefault"
 def interpSampleFn : Ident := mkIdent $ Name.mkStr3 "Plausible" "SampleableExt" "interpSample"
+
+/-- Ident for the inner `aux_arb` function that appears in derived generators -/
 def auxArbFn : Ident := mkIdent $ Name.mkStr1 "aux_arb"
+
+/-- Ident for the inner `aux_enum` function that appears in derived enumerators -/
 def auxEnumFn : Ident := mkIdent $ Name.mkStr1 "aux_enum"
+
+/-- Ident for the inner `aux_dec` function that appears in derived checkers -/
+def auxDecFn : Ident := mkIdent $ Name.mkStr1 "aux_dec"
+
 def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
 def someFn : Ident := mkIdent ``some

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -17,6 +17,8 @@ def interpSampleFn : Ident := mkIdent $ Name.mkStr3 "Plausible" "SampleableExt" 
 def auxArbFn : Ident := mkIdent $ Name.mkStr1 "aux_arb"
 def auxEnumFn : Ident := mkIdent $ Name.mkStr1 "aux_enum"
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
+def someFn : Ident := mkIdent $ Name.mkStr1 "some"
+def falseIdent : Ident := mkIdent ``false
 
 -- Idents for size arguments to generators
 def initSizeIdent : Ident := mkIdent $ Name.mkStr1 "initSize"

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -23,7 +23,7 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
   let rec aux_arb (initSize : Nat) (size : Nat) (Γ : List type) (x : Nat) (τ : type) : Option Bool :=
     match size with
     | .zero =>
-      checkerBacktrack [
+      DecOpt.checkerBacktrack [
         (fun _ =>
           match x with
           | .zero =>
@@ -38,7 +38,7 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
         fun _ => none
       ]
     | .succ size' =>
-      checkerBacktrack [
+      DecOpt.checkerBacktrack [
         (fun _ =>
           match Γ with
           | [] => some false
@@ -72,7 +72,7 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
   let rec aux_arb (initSize : Nat) (size : Nat) (Γ : List type) (e : term) (τ : type) : Option Bool :=
     match size with
     | .zero =>
-      checkerBacktrack [
+      DecOpt.checkerBacktrack [
         fun _ =>
           match e with
           | .Var x =>
@@ -91,7 +91,7 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
         fun _ => none
       ]
     | .succ size' =>
-      checkerBacktrack [
+      DecOpt.checkerBacktrack [
         fun _ =>
           match e with
           | .Var x =>

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -29,7 +29,7 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
           | .zero =>
             match Γ with
             | [] => some false
-            | t :: _ => DecOpt.andBind (DecOpt.decOpt (τ = t) initSize) (some true)
+            | t :: _ => DecOpt.andOptList [DecOpt.decOpt (τ = t) initSize]
           | .succ _ => some false),
         fun _ => none
       ]
@@ -38,14 +38,14 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
         (fun _ =>
           match Γ with
           | [] => some false
-          | t :: _ => DecOpt.andBind (DecOpt.decOpt (τ = t) initSize) (some true)),
+          | t :: _ => DecOpt.andOptList [DecOpt.decOpt (τ = t) initSize]),
         (fun _ =>
           match x with
           | .zero => some false
           | .succ x' =>
             match Γ with
             | [] => some false
-            | _ :: Γ' => DecOpt.andBind (aux_arb initSize size' Γ' x' τ) (some true))
+            | _ :: Γ' => DecOpt.andOptList [aux_arb initSize size' Γ' x' τ])
       ]
   fun size => aux_arb size size Γ x τ
 
@@ -63,7 +63,7 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
       DecOpt.checkerBacktrack [
         fun _ =>
           match e with
-          | .Var x => DecOpt.andBind (DecOpt.decOpt (lookup Γ x τ) initSize) (some true)
+          | .Var x => DecOpt.andOptList [DecOpt.decOpt (lookup Γ x τ) initSize]
           | _ => some false,
         fun _ =>
           match τ with
@@ -78,15 +78,17 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
       DecOpt.checkerBacktrack [
         fun _ =>
           match e with
-          | .Var x => DecOpt.andBind (DecOpt.decOpt (lookup Γ x τ) initSize) (some true)
+          | .Var x => DecOpt.andOptList [DecOpt.decOpt (lookup Γ x τ) initSize]
           | _ => some false,
         fun _ =>
           match τ with
           | .Nat =>
             match e with
             | .Add e1 e2 =>
-              DecOpt.andBind (aux_arb initSize size' Γ e1 .Nat) $
-                DecOpt.andBind (aux_arb initSize size' Γ e2 .Nat) (some true)
+              DecOpt.andOptList [
+                aux_arb initSize size' Γ e1 .Nat,
+                aux_arb initSize size' Γ e2 .Nat
+              ]
             | _ => some false
           | _ => none,
         fun _ =>
@@ -102,8 +104,10 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
           | .Fun unkn_17_ τ2 =>
             match e with
             | .Abs τ1 e =>
-              DecOpt.andBind (DecOpt.decOpt (τ1 = unkn_17_) initSize) $
-                DecOpt.andBind (aux_arb initSize size' (τ1 :: Γ) e τ2) (some true)
+              DecOpt.andOptList [
+                  DecOpt.decOpt (τ1 = unkn_17_) initSize,
+                  aux_arb initSize size' (τ1 :: Γ) e τ2
+              ]
             | _ => none,
         -- TODO: handle App case
       ]

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -29,7 +29,7 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
           | .zero =>
             match Γ with
             | [] => some false
-            | t :: _ => DecOpt.decOpt (τ = t) initSize
+            | t :: _ => DecOpt.andBind (DecOpt.decOpt (τ = t) initSize) (some true)
           | .succ _ => some false),
         fun _ => none
       ]
@@ -38,14 +38,14 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
         (fun _ =>
           match Γ with
           | [] => some false
-          | t :: _ => DecOpt.decOpt (τ = t) initSize),
+          | t :: _ => DecOpt.andBind (DecOpt.decOpt (τ = t) initSize) (some true)),
         (fun _ =>
           match x with
           | .zero => some false
           | .succ x' =>
             match Γ with
             | [] => some false
-            | _ :: Γ' => aux_arb initSize size' Γ' x' τ)
+            | _ :: Γ' => DecOpt.andBind (aux_arb initSize size' Γ' x' τ) (some true))
       ]
   fun size => aux_arb size size Γ x τ
 
@@ -63,7 +63,7 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
       DecOpt.checkerBacktrack [
         fun _ =>
           match e with
-          | .Var x => DecOpt.decOpt (lookup Γ x τ) initSize
+          | .Var x => DecOpt.andBind (DecOpt.decOpt (lookup Γ x τ) initSize) (some true)
           | _ => some false,
         fun _ =>
           match τ with
@@ -78,14 +78,15 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
       DecOpt.checkerBacktrack [
         fun _ =>
           match e with
-          | .Var x => DecOpt.decOpt (lookup Γ x τ) initSize
+          | .Var x => DecOpt.andBind (DecOpt.decOpt (lookup Γ x τ) initSize) (some true)
           | _ => some false,
         fun _ =>
           match τ with
           | .Nat =>
             match e with
             | .Add e1 e2 =>
-              DecOpt.andBind (aux_arb initSize size' Γ e1 .Nat) (aux_arb initSize size' Γ e2 .Nat)
+              DecOpt.andBind (aux_arb initSize size' Γ e1 .Nat) $
+                DecOpt.andBind (aux_arb initSize size' Γ e2 .Nat) (some true)
             | _ => some false
           | _ => none,
         fun _ =>
@@ -101,7 +102,8 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
           | .Fun unkn_17_ τ2 =>
             match e with
             | .Abs τ1 e =>
-              DecOpt.andBind (DecOpt.decOpt (τ1 = unkn_17_) initSize) (aux_arb initSize size' (τ1 :: Γ) e τ2)
+              DecOpt.andBind (DecOpt.decOpt (τ1 = unkn_17_) initSize) $
+                DecOpt.andBind (aux_arb initSize size' (τ1 :: Γ) e τ2) (some true)
             | _ => none,
         -- TODO: handle App case
       ]

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -93,9 +93,7 @@ def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
     cases := cases.push catchAllCase
 
     -- Create a pattern match that simultaneously matches on all the scrutinees
-    let matchExpr ← mkSimultaneousMatch scrutinees cases
-    logInfo m!"{matchExpr}"
-    return matchExpr
+    mkSimultaneousMatch scrutinees cases
   else
     return checkerBody
 

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -1,5 +1,6 @@
 import Lean
 import Plausible.IR.Constructor
+import Plausible.IR.Extractor
 import Plausible.New.Idents
 import Plausible.New.TSyntaxCombinators
 
@@ -10,11 +11,19 @@ open Lean Elab Command Meta Term Parser Std
 /-- Constructs terms which constitute calls to checkers corresponding
     to the hypotheses in `inductiveHypothesesToCheck`
     (these are either recursive calls to the current checker function, or invocations of
-    the `DecOpt` typeclass instance for the hypotheses) -/
-def mkSubCheckerBody (inductiveHypothesesToCheck : Array Action) : TermElabM (TSyntax `term) :=
+    the `DecOpt` typeclass instance for the hypotheses)
+    - The `ctor` argument is the constructor of the inductive relation corresponding to
+      the sub-checker being built -/
+def mkSubCheckerBody (inductiveHypothesesToCheck : Array Action) (ctor : InductiveConstructor) : TermElabM (TSyntax `term) :=
   if inductiveHypothesesToCheck.isEmpty then
     `($someFn:ident $trueIdent:ident)
   else
+    -- for hypothesis in inductiveHypothesesToCheck do
+    --   if let .checkInductive hyp := hypothesis then
+    --     if hypothesisRecursivelyCallsCurrentInductive hyp _ then
+    --       sorry
+
+
     -- TODO: fill in the list with sub-checker calls
     -- ^^ loop through `inductiveHypothesesToCheck` and use `hypothesisRecursivelyCallsCurrentInductive` to determine if
     -- checker call should be recursive or performed via typeclass resolution
@@ -28,7 +37,7 @@ def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
   logInfo m!"subChecker = {subChecker}"
 
   let inductiveHypothesesToCheck := subChecker.groupedActions.checkInductiveActions
-  let checkerBody ← mkSubCheckerBody inductiveHypothesesToCheck
+  let checkerBody ← mkSubCheckerBody inductiveHypothesesToCheck subChecker.ctor
 
   -- If there are inputs on which we need to perform a pattern-match,
       -- create a pattern-match expr which only returns the checker body

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -1,0 +1,52 @@
+import Lean
+import Plausible.IR.Constructor
+import Plausible.New.Idents
+import Plausible.New.TSyntaxCombinators
+
+open Plausible.IR
+open Idents
+open Lean Elab Command Meta Term Parser Std
+
+def mkSubCheckerBody : Unit → TermElabM (TSyntax `term) :=
+  -- TODO: fill in this body
+  sorry
+
+/-- Constructs an anonymous sub-checker. See the comments in the body of this function
+    for details on how this sub-checker is created. -/
+def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
+  -- TODO: we only need to iterate through check_IR & check_non_IR
+
+  -- TODO: use `hypothesisRecursivelyCallsCurrentInductive` to determine if
+  -- checker call should be recursive or performed via typeclass resolution
+  -- let checkerBody ← mkSubCheckerBody ()
+  let checkerBody ← `($someFn:ident $falseIdent:ident) -- TODO: replace
+
+
+  -- If there are inputs on which we need to perform a pattern-match,
+      -- create a pattern-match expr which only returns the checker body
+      -- if the match succeeds
+  if !subChecker.inputsToMatch.isEmpty then
+    let mut cases := #[]
+
+    -- Handle multiple scrutinees by giving all of them fresh names
+    let existingNames := Name.mkStr1 <$> subChecker.inputsToMatch
+    let scrutinees := Lean.mkIdent <$> Array.map (fun name => genFreshName existingNames name) existingNames
+
+    -- Construct the match expression based on the info in `matchCases`
+    let patterns ← Array.mapM (fun patternExpr => PrettyPrinter.delab patternExpr) subChecker.matchCases
+    -- If there are multiple scrutinees, the LHS of each case is a tuple containing the elements in `matchCases`
+    let case ← `(Term.matchAltExpr| | $[$patterns:term],* => $checkerBody:term)
+    cases := cases.push case
+
+    -- The LHS of the catch-all case contains a tuple consisting entirely of wildcards
+    let numScrutinees := Array.size scrutinees
+    let wildcards := Array.replicate numScrutinees (← `(_))
+    let catchAllCase ← `(Term.matchAltExpr| | $wildcards:term,* => $someFn:ident $falseIdent:ident)
+    cases := cases.push catchAllCase
+
+    -- Create a pattern match that simultaneously matches on all the scrutinees
+    let foo ← mkSimultaneousMatch scrutinees cases
+    logInfo m!"{foo}"
+    return foo
+  else
+    return checkerBody

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -100,8 +100,11 @@ def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
     return checkerBody
 
 /-- Takes an array of `SubCheckerInfo`s and creates a Lean term representing a
-    list of derived sub-checkers -/
-def mkSubCheckers (subCheckers : Array SubCheckerInfo) : TermElabM (TSyntax `term) := do
-  -- TODO: need to make each of the `subCheckerTerm`s below thunked
-  let subCheckerTerms ← Array.mapM mkSubChecker subCheckers
-  `([$subCheckerTerms,*])
+    list of thunked derived sub-checkers -/
+def mkThunkedSubCheckers (subCheckerInfos : Array SubCheckerInfo) : TermElabM (TSyntax `term) := do
+  let mut thunkedSubCheckers := #[]
+  for subChecker in subCheckerInfos do
+    let subCheckerBody ← mkSubChecker subChecker
+    thunkedSubCheckers := thunkedSubCheckers.push (← `(fun _ => $subCheckerBody))
+
+  `([$thunkedSubCheckers,*])

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -16,15 +16,14 @@ def mkSubCheckerBody (inductiveHypothesesToCheck : Array Action) : TermElabM (TS
     `($someFn:ident $trueIdent:ident)
   else
     -- TODO: fill in the list with sub-checker calls
+    -- ^^ loop through `inductiveHypothesesToCheck` and use `hypothesisRecursivelyCallsCurrentInductive` to determine if
+    -- checker call should be recursive or performed via typeclass resolution
     `($andOptListFn:ident [])
 
 /-- Constructs an anonymous sub-checker. See the comments in the body of this function
     for details on how this sub-checker is created. -/
 def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
   -- TODO: we only need to iterate through check_IR & check_non_IR
-
-  -- TODO: use `hypothesisRecursivelyCallsCurrentInductive` to determine if
-  -- checker call should be recursive or performed via typeclass resolution
 
   logInfo m!"subChecker = {subChecker}"
 

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -7,9 +7,16 @@ open Plausible.IR
 open Idents
 open Lean Elab Command Meta Term Parser Std
 
-def mkSubCheckerBody : Unit → TermElabM (TSyntax `term) :=
-  -- TODO: fill in this body
-  sorry
+/-- Constructs terms which constitute calls to checkers corresponding
+    to the hypotheses in `inductiveHypothesesToCheck`
+    (these are either recursive calls to the current checker function, or invocations of
+    the `DecOpt` typeclass instance for the hypotheses) -/
+def mkSubCheckerBody (inductiveHypothesesToCheck : Array Action) : TermElabM (TSyntax `term) :=
+  if inductiveHypothesesToCheck.isEmpty then
+    `($someFn:ident $trueIdent:ident)
+  else
+    -- TODO: fill in the list with sub-checker calls
+    `($andOptListFn:ident [])
 
 /-- Constructs an anonymous sub-checker. See the comments in the body of this function
     for details on how this sub-checker is created. -/
@@ -18,9 +25,11 @@ def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
 
   -- TODO: use `hypothesisRecursivelyCallsCurrentInductive` to determine if
   -- checker call should be recursive or performed via typeclass resolution
-  -- let checkerBody ← mkSubCheckerBody ()
-  let checkerBody ← `($someFn:ident $falseIdent:ident) -- TODO: replace
 
+  logInfo m!"subChecker = {subChecker}"
+
+  let inductiveHypothesesToCheck := subChecker.groupedActions.checkInductiveActions
+  let checkerBody ← mkSubCheckerBody inductiveHypothesesToCheck
 
   -- If there are inputs on which we need to perform a pattern-match,
       -- create a pattern-match expr which only returns the checker body

--- a/Plausible/New/SubCheckers.lean
+++ b/Plausible/New/SubCheckers.lean
@@ -98,3 +98,10 @@ def mkSubChecker (subChecker : SubCheckerInfo) : TermElabM (TSyntax `term) := do
     return matchExpr
   else
     return checkerBody
+
+/-- Takes an array of `SubCheckerInfo`s and creates a Lean term representing a
+    list of derived sub-checkers -/
+def mkSubCheckers (subCheckers : Array SubCheckerInfo) : TermElabM (TSyntax `term) := do
+  -- TODO: need to make each of the `subCheckerTerm`s below thunked
+  let subCheckerTerms ← Array.mapM mkSubChecker subCheckers
+  `([$subCheckerTerms,*])

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -14,9 +14,9 @@ open Idents
       `let fvar ← aux_arb size e1 … en`, where `e1, …, en` are the arguments to the
       a hypothesis `hyp` for an inductive relation with the argument at index `idx` removed
       (since `fvar` is the argument at index `idx`, and we are generating `fvar`)
-    - If `generationStyle = .TypeClassresolution`, we produce the term
+    - If `generationStyle = .TypeClassResolution`, we produce the term
       `let fvar ← ArbitrarySuchThat.arbitraryST (fun fvar => hyp)`, i.e.
-      we use typeclass resolution to invoke the generator from the
+      we use typeclass resolution to invoke the generator from the typeclass function
       `ArbitrarySuchThat.arbitraryST` which produces values satisfying the hypothesis `hyp`
       (note: this requires that such an typeclass instance already exists). -/
 def genInputForInductive (fvar : FVarId) (hyp : Expr) (idx : Nat) (generationStyle : GenerationStyle) : MetaM (TSyntax `doElem) := do

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -7,6 +7,7 @@ import Plausible.New.Arbitrary
 import Plausible.New.ArbitrarySizedSuchThat
 import Plausible.New.EnumeratorCombinators
 import Plausible.New.DeriveEnum
+import Plausible.New.DeriveChecker
 import Plausible.New.STLC
 
 
@@ -53,7 +54,6 @@ inductive MyListAnon where
 -- #derive_arbitrary Value
 
 -- #eval runArbitrary (α := MyList) 10
-
 
 
 /- Example usage:

--- a/Plausible/New/Trees.lean
+++ b/Plausible/New/Trees.lean
@@ -107,7 +107,7 @@ def tempSize := 10
 /-- Handwritten `DecOpt` instance for the proposition `bst lo hi t` -/
 instance : DecOpt (bst lo hi t) where
   decOpt :=
-    let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
+    let rec aux_arb (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
       match size with
       | .zero =>
         DecOpt.checkerBacktrack [
@@ -128,9 +128,9 @@ instance : DecOpt (bst lo hi t) where
             | .Leaf => some false
             | .Node x l r =>
               DecOpt.andOptList [
-                DecOpt.decOpt (lo_0 < x && x < hi_0) init_size,
-                aux_arb init_size size' lo_0 x l,
-                aux_arb init_size size' x hi_0 r
+                DecOpt.decOpt (lo_0 < x && x < hi_0) initSize,
+                aux_arb initSize size' lo_0 x l,
+                aux_arb initSize size' x hi_0 r
               ]
         ]
     fun size => aux_arb size size lo hi t

--- a/Plausible/New/Trees.lean
+++ b/Plausible/New/Trees.lean
@@ -104,7 +104,7 @@ def tempSize := 10
 -/
 
 
--- Handwritten `DecOpt` instance for the proposition `bst lo hi t`
+/-- Handwritten `DecOpt` instance for the proposition `bst lo hi t` -/
 instance : DecOpt (bst lo hi t) where
   decOpt :=
     let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
@@ -134,3 +134,52 @@ instance : DecOpt (bst lo hi t) where
               ]
         ]
     fun size => aux_arb size size lo hi t
+
+/-- Handwritten `DecOpt` instance for the proposition `balanced n t` -/
+instance : DecOpt (balanced n t) where
+  decOpt :=
+    let rec aux_arb (initSize : Nat) (size : Nat) (n_0 : Nat) (t_0 : Tree) : Option Bool :=
+      match size with
+      | .zero =>
+        DecOpt.checkerBacktrack [
+          (fun _ =>
+            match t_0 with
+            | .Leaf => match n_0 with
+                      | 0 => some true
+                      | _ => some false
+            | _ => some false),
+          (fun _ =>
+            match t_0 with
+            | .Leaf => match n_0 with
+                      | 1 => some true
+                      | _ => some false
+            | _ => some false),
+          (fun _ => none)
+        ]
+      | .succ size' =>
+        DecOpt.checkerBacktrack [
+          (fun _ =>
+            match t_0 with
+            | .Leaf => match n_0 with
+                      | 0 => some true
+                      | _ => some false
+            | _ => some false),
+          (fun _ =>
+            match t_0 with
+            | .Leaf => match n_0 with
+                      | 1 => some true
+                      | _ => some false
+            | _ => some false),
+          (fun _ =>
+            match t_0 with
+            | .Leaf => some false
+            | .Node _ l r =>
+              match n_0 with
+              | .succ n =>
+                DecOpt.andOptList [
+                  aux_arb initSize size' n l,
+                  aux_arb initSize size' n r
+                ]
+              | _ => some false)
+        ]
+    fun size => aux_arb size size n t

--- a/Plausible/New/Trees.lean
+++ b/Plausible/New/Trees.lean
@@ -127,7 +127,10 @@ instance : DecOpt (bst lo hi t) where
             match t_0 with
             | .Leaf => some false
             | .Node x l r =>
-              DecOpt.andBind (DecOpt.decOpt (lo_0 < x && x < hi_0) init_size) $
-                DecOpt.andBind (aux_arb init_size size' lo_0 x l) (aux_arb init_size size' x hi_0 r)
+              DecOpt.andOptList [
+                DecOpt.decOpt (lo_0 < x && x < hi_0) init_size,
+                aux_arb init_size size' lo_0 x l,
+                aux_arb init_size size' x hi_0 r
+              ]
         ]
     fun size => aux_arb size size lo hi t

--- a/Plausible/New/Trees.lean
+++ b/Plausible/New/Trees.lean
@@ -110,7 +110,7 @@ instance : DecOpt (bst lo hi t) where
     let rec aux_arb (init_size : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : Tree) : Option Bool :=
       match size with
       | .zero =>
-        checkerBacktrack [
+        DecOpt.checkerBacktrack [
           fun _ =>
             match t_0 with
             | .Leaf => some true
@@ -118,7 +118,7 @@ instance : DecOpt (bst lo hi t) where
           fun _ => none
         ]
       | .succ size' =>
-        checkerBacktrack [
+        DecOpt.checkerBacktrack [
           fun _ =>
             match t_0 with
             | .Leaf => some true
@@ -127,15 +127,7 @@ instance : DecOpt (bst lo hi t) where
             match t_0 with
             | .Leaf => some false
             | .Node x l r =>
-              match DecOpt.decOpt (lo_0 < x && x < hi_0) init_size with
-              | some true => match aux_arb init_size size' lo_0 x l with
-                             | some true => match aux_arb init_size size' x hi_0 r with
-                                            | some true => some true
-                                            | some false => some false
-                                            | none => none
-                             | some false => some false
-                             | none => none
-              | some false => some false
-              | none => none
+              DecOpt.andBind (DecOpt.decOpt (lo_0 < x && x < hi_0) init_size) $
+                DecOpt.andBind (aux_arb init_size size' lo_0 x l) (aux_arb init_size size' x hi_0 r)
         ]
     fun size => aux_arb size size lo hi t

--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 
 **Metaprogramming infrastructure**:
 - [`TSyntaxCombinators.lean`](./Plausible/New/TSyntaxCombinators.lean): Combinators over `TSyntax` for creating monadic `do`-blocks & other Lean expressions via metaprogramming
-- [`DeriveArbitrary.lean`](./Plausible/New/DeriveArbitrary.lean): Metaprogramming infrastructure for deriving *unconstrained* generators (instances of the `ArbitrarySized` typeclass)
+- [`DeriveArbitrary.lean`](./Plausible/New/DeriveArbitrary.lean): Metaprogramming infrastructure for deriving unconstrained generators (instances of the `Arbitrary` / `ArbitrarySized` typeclasses)
+- [`DeriveEnum.lean`](./Plausible/New/DeriveEnum.lean): Metaprogramming infrastructure for deriving unconstrainted enumerators 
+(instances of the `Enum` / `EnumSized` typeclasses) 
 - [`DeriveGenerator.lean`](./Plausible/New/DeriveGenerator.lean): Metaprogramming infrastructure for deriving *constrained* generators (instances of the `ArbitrarySizedSuchThat` typeclass)
-- [`SubGenerators.lean`](./Plausible/New/SubGenerators.lean): Handles constraints when deriving sub-generators
-- [`DeriveChecker.lean`](./Plausible/New/DeriveChecker.lean): Metaprogramming infrastructure for automatically deriving checkers
+- [`DeriveChecker.lean`](./Plausible/New/DeriveChecker.lean): Metaprogramming infrastructure for automatically deriving checkers (instances of the `DecOpt` typeclass)
+- [`SubGenerators.lean`](./Plausible/New/SubGenerators.lean): Handles constraints when deriving sub-generators (handlers invoked by top-level derived generators)
+- [`SubCheckers.lean`](./Plausible/New/SubCheckers.lean): Handles constraints when deriving sub-checkers (handlers invoked by top-level derived checkers)
 
 **Miscellany**:
 - [`LazyList.lean`](./Plausible/New/LazyList.lean): Implementation of lazy lists (used for enumerators)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Our design is heavily inspired by [Coq/Rocq's QuickChick](https://github.com/Qui
 
 
 ## Overview
-Like QuickChick & [Haskell QuickChick](https://hackage.haskell.org/package/QuickCheck), we provide the following typeclasses for random generation:
+Like QuickChick & [Haskell QuickCheck](https://hackage.haskell.org/package/QuickCheck), we provide the following typeclasses for random generation:
 - `Arbitrary`: random generators for inhabitants of algebraic data types
 - `ArbitrarySuchThat`: generators which only produce random values that satisfy a user-supplied inductive relation
 - `ArbitrarySized`, `ArbitrarySizedSuchThat`: versions of the two typeclasses above where the generator's size parameter is made explicit 

--- a/Test.lean
+++ b/Test.lean
@@ -6,7 +6,7 @@ Authors: Henrik Böving
 -- import Test.Tactic
 -- import Test.Testable
 
--- Tests for `#derive_generator` (`derives ArbitrarySuchThat`)
+-- Tests for `#derive_generator` (derives `ArbitrarySuchThat`)
 import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
 import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
@@ -34,3 +34,11 @@ import Test.DeriveEnum.DeriveNKIBinopEnumerator
 import Test.DeriveEnum.DeriveRegExpEnumerator
 import Test.DeriveEnum.StructureTest
 import Test.DeriveEnum.BitVecStructureTest
+
+-- Tests for `#derive_checker` (derives `DecOpt`)
+import Test.DeriveDecOpt.DeriveBSTChecker
+import Test.DeriveDecOpt.DeriveBalancedTreeChecker
+import Test.DeriveDecOpt.DeriveRegExpMatchChecker
+import Test.DeriveDecOpt.NonLinearPatternsTest
+import Test.DeriveDecOpt.SimultaneousMatchingTests
+import Test.DeriveDecOpt.DeriveSTLCChecker

--- a/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
@@ -8,6 +8,8 @@ open ArbitrarySizedSuchThat OptionTGen
 
 set_option guard_msgs.diff true
 
+-- TODO: investigate why `τ'` and not `τ` is appearing as the head of the list in the final pattern-match
+
 /--
 info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun x => lookup Γ x τ) where
   arbitrarySizedST :=

--- a/Test/DeriveDecOpt/DeriveBSTChecker.lean
+++ b/Test/DeriveDecOpt/DeriveBSTChecker.lean
@@ -1,0 +1,36 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this checker: instance : DecOpt (BST lo hi t) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) (t_0 : BinaryTree) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match t_0 with
+            | BinaryTree.Leaf => Option.some Bool.true
+            | _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match t_0 with
+            | BinaryTree.Leaf => Option.some Bool.true
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match t_0 with
+            | BinaryTree.Node x l r =>
+              DecOpt.andOptList
+                [DecOpt.decOpt (@LT.lt Nat instLTNat lo x) initSize, DecOpt.decOpt (@LT.lt Nat instLTNat x hi) initSize,
+                  aux_dec initSize size' lo x l, aux_dec initSize size' x hi r]
+            | _ => Option.some Bool.false]
+    fun size => aux_dec size size lo hi t
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (BST lo hi t)

--- a/Test/DeriveDecOpt/DeriveBalancedTreeChecker.lean
+++ b/Test/DeriveDecOpt/DeriveBalancedTreeChecker.lean
@@ -1,0 +1,43 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveDecOpt.DeriveBSTChecker
+import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this checker: instance : DecOpt (balancedTree n t) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (n_0 : Nat) (t_0 : BinaryTree) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match n_0, t_0 with
+            | 0, BinaryTree.Leaf => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match n_0, t_0 with
+            | 1, BinaryTree.Leaf => Option.some Bool.true
+            | _, _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match n_0, t_0 with
+            | 0, BinaryTree.Leaf => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match n_0, t_0 with
+            | 1, BinaryTree.Leaf => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match n_0, t_0 with
+            | Nat.succ n, BinaryTree.Node x l r =>
+              DecOpt.andOptList [aux_dec initSize size' n l, aux_dec initSize size' n r]
+            | _, _ => Option.some Bool.false]
+    fun size => aux_dec size size n t
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (balancedTree n t)

--- a/Test/DeriveDecOpt/DeriveRegExpMatchChecker.lean
+++ b/Test/DeriveDecOpt/DeriveRegExpMatchChecker.lean
@@ -1,0 +1,67 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveArbitrary.DeriveRegExpGenerator
+import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+-- TODO: handle function calls in pattern matches!
+
+
+/-
+info: Try this checker: instance : DecOpt (ExpMatch s r0) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (s_0 : List Nat) (r0_0 : RegExp) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match s_0, r0_0 with
+            | [], RegExp.EmptyStr => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | [x], RegExp.Char x_0 => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | [], RegExp.Star re => Option.some Bool.true
+            | _, _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match s_0, r0_0 with
+            | [], RegExp.EmptyStr => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | [x], RegExp.Char x_0 => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | s1 ++ s2, RegExp.App re1 re2 =>
+              DecOpt.andOptList [aux_dec initSize size' s1 re1, aux_dec initSize size' s2 re2]
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match r0_0 with
+            | RegExp.Union re1 re2 => DecOpt.andOptList [aux_dec initSize size' s re1]
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match r0_0 with
+            | RegExp.Union re1 re2 => DecOpt.andOptList [aux_dec initSize size' s re2]
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | [], RegExp.Star re => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match s_0, r0_0 with
+            | s1 ++ s2, RegExp.Star re =>
+              DecOpt.andOptList [aux_dec initSize size' s1 re, aux_dec initSize size' s2 (RegExp.Star re)]
+            | _, _ => Option.some Bool.false]
+    fun size => aux_dec size size s r0
+-/
+-- #guard_msgs(info, drop warning) in
+-- #derive_checker (ExpMatch s r0)

--- a/Test/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/Test/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -1,0 +1,36 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveDecOpt.DeriveBSTChecker
+import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+-- TODO: investigate why `τ'` and not `τ` is appearing as the head of the list in the final pattern-match
+
+/--
+info: Try this checker: instance : DecOpt (lookup Γ x τ) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (Γ_0 : List type) (x_0 : Nat) (τ_0 : type) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match Γ_0, x_0 with
+            | τ :: Γ, 0 => Option.some Bool.true
+            | _, _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match Γ_0, x_0 with
+            | τ :: Γ, 0 => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match Γ_0, x_0 with
+            | τ' :: Γ, Nat.succ n => DecOpt.andOptList [aux_dec initSize size' Γ n τ]
+            | _, _ => Option.some Bool.false]
+    fun size => aux_dec size size Γ x τ
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (lookup Γ x τ)

--- a/Test/DeriveDecOpt/NonLinearPatternsTest.lean
+++ b/Test/DeriveDecOpt/NonLinearPatternsTest.lean
@@ -1,0 +1,33 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveDecOpt.DeriveBSTChecker
+import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+-- TODO: (fix this)
+-- we want to invoke `in2_0 = in1_0` in the checker, not `in1 = in1_0`!
+
+/--
+info: Try this checker: instance : DecOpt (GoodTree in1 in2 t) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (in1_0 : Nat) (in2_0 : Nat) (t_0 : BinaryTree) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match t_0 with
+            | BinaryTree.Leaf => Option.some Bool.true
+            | _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match t_0 with
+            | BinaryTree.Leaf => Option.some Bool.true
+            | _ => Option.some Bool.false]
+    fun size => aux_dec size size in1 in2 t
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (GoodTree in1 in2 t)

--- a/Test/DeriveDecOpt/SimultaneousMatchingTests.lean
+++ b/Test/DeriveDecOpt/SimultaneousMatchingTests.lean
@@ -1,0 +1,68 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+import Test.DeriveDecOpt.DeriveBSTChecker
+import Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this checker: instance : DecOpt (MinOk l a) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (l_0 : List Nat) (a_0 : List Nat) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l_0, a_0 with
+            | [], [] => Option.some Bool.true
+            | _, _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l_0, a_0 with
+            | [], [] => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match a_0 with
+            | x :: l' =>
+              DecOpt.andOptList
+                [DecOpt.decOpt (@Membership.mem Nat (List Nat) List.instMembership l x) initSize,
+                  aux_dec initSize size' l l']
+            | _ => Option.some Bool.false]
+    fun size => aux_dec size size l a
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (MinOk l a)
+
+/--
+info: Try this checker: instance : DecOpt (MinEx n l a) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (n_0 : Nat) (l_0 : List Nat) (a_0 : List Nat) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match n_0, l_0, a_0 with
+            | 0, [], [] => Option.some Bool.true
+            | _, _, _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match n_0, l_0, a_0 with
+            | 0, [], [] => Option.some Bool.true
+            | _, _, _ => Option.some Bool.false,
+            fun _ =>
+            match n_0, a_0 with
+            | Nat.succ n, x :: l' =>
+              DecOpt.andOptList
+                [DecOpt.decOpt (@Membership.mem Nat (List Nat) List.instMembership l x) initSize,
+                  aux_dec initSize size' n l l']
+            | _, _ => Option.some Bool.false]
+    fun size => aux_dec size size n l a
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (MinEx n l a)
+
+-- TODO: test derived checkers on the other examples in `Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests`

--- a/Test/Enum/EnumInstancesTest.lean
+++ b/Test/Enum/EnumInstancesTest.lean
@@ -2,56 +2,46 @@ import Plausible.New.Enumerators
 
 /-- info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] -/
 #guard_msgs in
-#eval (Enum.enum 15 : LazyList Nat)
+#eval (runEnum (α := Nat) 15)
 
 /-- info: [0, 1, 2, 3, 4, 5, 6, 7] -/
 #guard_msgs in
-#eval (Enum.enum 7 : LazyList Nat)
+#eval (runEnum (α := Nat) 7)
 
 /-- info: [0, 1, 2, 3, 4] -/
 #guard_msgs in
-#eval (Enum.enum 5 : LazyList (Fin 5))
+#eval (runEnum (α := Fin 5) 5)
 
 /-- info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] -/
 #guard_msgs in
-#eval (Enum.enum 10 : LazyList (Fin 10))
+#eval (runEnum (α := Fin 10) 10)
 
 
 /-- info: [false, true] -/
 #guard_msgs in
-#eval (Enum.enum 10 : LazyList Bool)
+#eval (runEnum (α := Bool) 10)
 
 /--
-info: [(0, false),
- (0, true),
- (1, false),
- (1, true),
- (2, false),
- (2, true),
- (3, false),
- (3, true),
- (4, false),
- (4, true),
- (5, false),
- (5, true)]
+info: [(0, false), (0, true), (1, false), (1, true), (2, false), (2, true), (3, false), (3, true), (4, false), (4, true),
+  (5, false), (5, true)]
 -/
 #guard_msgs in
-#eval (Enum.enum 5 : LazyList (Nat × Bool))
+#eval (runEnum (α := Nat × Bool) 5)
 
 /--
 info: [Sum.inl 0, Sum.inl 1, Sum.inl 2, Sum.inl 3, Sum.inl 4, Sum.inl 5, Sum.inr false, Sum.inr true]
 -/
 #guard_msgs in
-#eval (Enum.enum 5 : LazyList (Nat ⊕ Bool))
+#eval (runEnum (α := Nat ⊕ Bool) 5)
 
 /--
 info: [[], [0], [0, 0], [0, 1], [1], [1, 0], [1, 1], [2], [2, 0], [2, 1], [3], [3, 0], [3, 1]]
 -/
 #guard_msgs in
-#eval (Enum.enum 3 : LazyList (List Nat))
+#eval (runEnum (α := List Nat) 3)
 
 /--
 info: [' ', '!', '\"', '#', '$', '%', '&', ''', '(', ')', '*', '+', ',', '-', '.', '/', '0', '1', '2', '3']
 -/
 #guard_msgs in
-#eval (Enum.enum 20 : LazyList Char)
+#eval (runEnum (α := Char) 20)


### PR DESCRIPTION
This PR adds support for deriving checkers for inductive propositions. 

A checker for an inductively-defined `Prop` is a `Nat -> Option Bool` function, which takes a `Nat` argument as fuel and returns `none` if it can't decide whether the `Prop` holds (e.g. it runs out of fuel), and otherwise returns `some true/some false` depending on whether the `Prop` holds.

We provide a command elaborator which elaborates the `#derive_checker` command:

```lean
-- `#derive_checker` derives a checker which determines whether `Tree`s `t` satisfy an inductive proposition called `balanced` 
#derive_checker (balanced n t)
```