### PR TITLE
Handle function calls that appear in the conclusion of constructors

### DIFF
--- a/Plausible/IR/Constructor.lean
+++ b/Plausible/IR/Constructor.lean
@@ -409,10 +409,10 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
   -- (otherwise, the generator needs to make a recursive call and is thus inductively-defined)
   let generatorSort := if ctor.recursive_hypotheses.isEmpty then .BaseGenerator else .InductiveGenerator
 
-  logWarning "*******************************"
-  logWarning m!"inputsToMatch = {inputsToMatch}"
-  logWarning m!"matchCases = {matchCases}"
-  logWarning "*******************************"
+  -- logWarning "*******************************"
+  -- logWarning m!"inputsToMatch = {inputsToMatch}"
+  -- logWarning m!"matchCases = {matchCases}"
+  -- logWarning "*******************************"
 
   return {
     inputs := (List.eraseIdx inputNamesList idx).toArray
@@ -428,7 +428,7 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
     - e.g. `vars = ["1", "2", ...]`
 -/
 def backtrackElem_if_return_producer (subGeneratorInfo : SubGeneratorInfo) (indentation : String) (vars: List String) (monad: String :="IO"): MetaM String := do
-  logWarning "inside backtrackElem_if_return_producer"
+  -- logWarning "inside backtrackElem_if_return_producer"
   -- logWarning m!"subGeneratorInfo = {subGeneratorInfo}"
 
   let mut out := ""

--- a/Plausible/IR/Constructor.lean
+++ b/Plausible/IR/Constructor.lean
@@ -409,11 +409,6 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
   -- (otherwise, the generator needs to make a recursive call and is thus inductively-defined)
   let generatorSort := if ctor.recursive_hypotheses.isEmpty then .BaseGenerator else .InductiveGenerator
 
-  -- logWarning "*******************************"
-  -- logWarning m!"inputsToMatch = {inputsToMatch}"
-  -- logWarning m!"matchCases = {matchCases}"
-  -- logWarning "*******************************"
-
   return {
     inputs := (List.eraseIdx inputNamesList idx).toArray
     inputsToMatch := inputsToMatch.toArray
@@ -428,9 +423,6 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
     - e.g. `vars = ["1", "2", ...]`
 -/
 def backtrackElem_if_return_producer (subGeneratorInfo : SubGeneratorInfo) (indentation : String) (vars: List String) (monad: String :="IO"): MetaM String := do
-  -- logWarning "inside backtrackElem_if_return_producer"
-  -- logWarning m!"subGeneratorInfo = {subGeneratorInfo}"
-
   let mut out := ""
   if subGeneratorInfo.variableEqualities.size + subGeneratorInfo.groupedActions.checkNonInductiveActions.size + subGeneratorInfo.groupedActions.checkInductiveActions.size > 0 then
     out := out ++ indentation ++ "if "

--- a/Plausible/IR/Examples.lean
+++ b/Plausible/IR/Examples.lean
@@ -50,18 +50,18 @@ inductive lookup : List type -> Nat -> type -> Prop where
 
 /- `typing Γ e τ` is the typing judgement `Γ ⊢ e : τ` -/
 inductive typing: List type → term → type → Prop where
--- | TConst : ∀ n,
---     typing Γ (.Const n) .Nat
--- | TAdd: ∀ e1 e2,
---     typing Γ e1 .Nat →
---     typing Γ e2 .Nat →
---     typing Γ (.Add e1 e2) .Nat
--- | TAbs: ∀ e τ1 τ2,
---     typing (τ1::Γ) e τ2 →
---     typing Γ (.Abs τ1 e) (.Fun τ1 τ2)
--- | TVar: ∀ x τ,
---     lookup Γ x τ →
---     typing Γ (.Var x) τ
+| TConst : ∀ n,
+    typing Γ (.Const n) .Nat
+| TAdd: ∀ e1 e2,
+    typing Γ e1 .Nat →
+    typing Γ e2 .Nat →
+    typing Γ (.Add e1 e2) .Nat
+| TAbs: ∀ e τ1 τ2,
+    typing (τ1::Γ) e τ2 →
+    typing Γ (.Abs τ1 e) (.Fun τ1 τ2)
+| TVar: ∀ x τ,
+    lookup Γ x τ →
+    typing Γ (.Var x) τ
 | TApp: ∀ e1 e2 τ1 τ2,
     typing Γ e2 τ1 →
     typing Γ e1 (.Fun τ1 τ2) →

--- a/Plausible/IR/Extractor.lean
+++ b/Plausible/IR/Extractor.lean
@@ -316,7 +316,8 @@ def process_constructor_unify_args (ctor_type: Expr) (input_vars : Array Expr) (
 
       -- TODO: check if `conclusion` contains any subterms that are function calls
       -- (use `Expr.isApp` and possibly `Expr.forEach`)
-      -- If yes, create a fresh variable & bind it to the result of the function call
+      -- If yes, create a fresh variable & add an extra hypothesis where the fresh var is bound to the result of the function call,
+      -- then rewrite the conclusion, replacing occurrences of the function call with the fresh variable
 
       unify_args_with_conclusion hypotheses conclusion arg_names bound_var_ctx
 

--- a/Plausible/IR/Extractor.lean
+++ b/Plausible/IR/Extractor.lean
@@ -76,11 +76,13 @@ def isInductiveRelation (tyexpr : Expr) : MetaM Bool := do
     and add the new variable (along with its type) to `boundVarCtx`.
     The updated hypotheses, conclusion and `boundVarCtx` are subsequently returned.
     - Note: it is the caller's responsibility to check that `conclusion` does indeed contain
-      a function application (e.g. by using `containsNonTrivialFuncApp`) -/
+      a non-trivial function application (e.g. by using `containsNonTrivialFuncApp`) -/
 def rewriteFuncCallsInConclusion (hypotheses : Array Expr) (conclusion : Expr) (inductiveRelationName : Name)
   (boundVarCtx : HashMap FVarId Expr) : MetaM (Array Expr × Expr × HashMap FVarId Expr) :=
 
   -- Filter out cases where the function being called is the same as the inductive relation's name
+  -- Note: this analysis is more simplistic compared to the one performed by `containsNonTrivialFuncApp`,
+  -- which is why callers should have called `containsNonTrivialFuncApp` beforehand
   let possibleFuncApp := Expr.find? (fun subExpr =>
     subExpr.isApp && subExpr.getAppFn.constName.getRoot != inductiveRelationName) conclusion
 

--- a/Plausible/IR/Extractor.lean
+++ b/Plausible/IR/Extractor.lean
@@ -313,6 +313,11 @@ def process_constructor_unify_args (ctor_type: Expr) (input_vars : Array Expr) (
   match splitLast? components_of_arrow_type with
   | some (hypotheses, conclusion) =>
     let (hypotheses, conclusion, new_ctx) ←
+
+      -- TODO: check if `conclusion` contains any subterms that are function calls
+      -- (use `Expr.isApp` and possibly `Expr.forEach`)
+      -- If yes, create a fresh variable & bind it to the result of the function call
+
       unify_args_with_conclusion hypotheses conclusion arg_names bound_var_ctx
 
     let (bound_vars, _) := bound_vars_and_types.unzip

--- a/Plausible/IR/Renaming.lean
+++ b/Plausible/IR/Renaming.lean
@@ -116,13 +116,8 @@ def testSimpleRenaming : MetaM Unit := do
   withLocalDeclD `size' (Expr.const `Nat []) fun sizeExVar => do
   withLocalDeclD `l (Expr.const `Tree []) fun lExpr => do
 
-
-    -- logWarning m!"=== TESTING SIMPLE RENAMING ==="
-    -- logWarning m!"Original nExpr name: {nExpr}"
-
     -- Create a match case that causes shadowing
     let matchCase := Expr.app (Expr.const `Nat.succ []) nExpr
-    -- logWarning m!"Match case: {matchCase}"
 
     -- Create expressions that reference the pattern variable
     let auxArbCall := mkApp2 (Expr.const `aux_arb []) sizeExVar nExpr

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -116,7 +116,7 @@ def checkTyping (Γ : List type) (e : term) (τ : type) : Nat → Option Bool :=
             | _ => none,
         fun _ =>
           match e with
-          | .App e1 e2 =>
+          | .App (.Abs .Nat e1) e2 =>
             EnumeratorCombinators.enumeratingOpt
               (EnumSuchThat.enumST (fun t1 => typing Γ e2 t1))
               (fun t1 => aux_arb initSize size' Γ e1 (.Fun t1 τ))

--- a/Plausible/New/STLC.lean
+++ b/Plausible/New/STLC.lean
@@ -55,7 +55,8 @@ def checkLookup (Γ : List type) (x : Nat) (τ : type) : Nat → Option Bool :=
 instance : DecOpt (lookup Γ x τ) where
   decOpt := checkLookup Γ x τ
 
--- TODO: fill in `EnumSizedSuchThat` instance
+-- Dummy `EnumSizedSuchThat` instance
+-- TODO: implement metaprogramming infrastructure for deriving `EnumSizedSuchThat` instances
 instance : EnumSizedSuchThat type (fun τ => typing Γ e τ) where
   enumSizedST := fun _ => OptionT.fail
 

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -163,23 +163,21 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
 
       inductiveHypothesesToCheck := inductiveHypothesesToCheck.push typedInductiveTerm
 
-  logWarning "**********************"
-
   -- Add equality checks for any pairs of variables in `variableEqualities`
   let mut variableEqualitiesToCheck := #[]
   for (fvar1, fvar2) in subGenerator.variableEqualities do
     let ident1 := mkIdent fvar1.name
     let ident2 := mkIdent fvar2.name
-    logWarning m!"ident1 = {ident1}, ident2 = {ident2}"
+    -- logWarning m!"ident1 = {ident1}, ident2 = {ident2}"
     let equalityCheck ← `($ident1:ident = $ident2:ident)
     variableEqualitiesToCheck := variableEqualitiesToCheck.push equalityCheck
 
-  logWarning m!"nonInductiveHypothesesToCheck = {nonInductiveHypothesesToCheck}"
-  logWarning m!"inductivesToCheck = {inductiveHypothesesToCheck}"
-  logWarning m!"variableEqualitiesToCheck = {variableEqualitiesToCheck}"
-  logWarning m!"doElems = {doElems}"
-  logWarning m!"inputsToMatch = {subGenerator.inputsToMatch}"
-  logWarning m!"matchCases = {subGenerator.matchCases}"
+  -- logWarning m!"nonInductiveHypothesesToCheck = {nonInductiveHypothesesToCheck}"
+  -- logWarning m!"inductivesToCheck = {inductiveHypothesesToCheck}"
+  -- logWarning m!"variableEqualitiesToCheck = {variableEqualitiesToCheck}"
+  -- logWarning m!"doElems = {doElems}"
+  -- logWarning m!"inputsToMatch = {subGenerator.inputsToMatch}"
+  -- logWarning m!"matchCases = {subGenerator.matchCases}"
 
   -- TODO: change `groupedActions.ret_list` to a single element since each do-block can only
   -- have one (final) `return` expression

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -113,8 +113,6 @@ def mkSubGeneratorBody (doBlock : TSyntaxArray `doElem) (argToGenTerm : Term) (n
 def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term) := do
   let mut doElems := #[]
 
-  logWarning m!"gen_list = {subGenerator.groupedActions.gen_list}"
-
   for action in subGenerator.groupedActions.gen_list do
     match action with
     | .genInputForInductive fvar hyp idx style =>

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -166,16 +166,8 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
   for (fvar1, fvar2) in subGenerator.variableEqualities do
     let ident1 := mkIdent fvar1.name
     let ident2 := mkIdent fvar2.name
-    -- logWarning m!"ident1 = {ident1}, ident2 = {ident2}"
     let equalityCheck ← `($ident1:ident = $ident2:ident)
     variableEqualitiesToCheck := variableEqualitiesToCheck.push equalityCheck
-
-  -- logWarning m!"nonInductiveHypothesesToCheck = {nonInductiveHypothesesToCheck}"
-  -- logWarning m!"inductivesToCheck = {inductiveHypothesesToCheck}"
-  -- logWarning m!"variableEqualitiesToCheck = {variableEqualitiesToCheck}"
-  -- logWarning m!"doElems = {doElems}"
-  -- logWarning m!"inputsToMatch = {subGenerator.inputsToMatch}"
-  -- logWarning m!"matchCases = {subGenerator.matchCases}"
 
   -- TODO: change `groupedActions.ret_list` to a single element since each do-block can only
   -- have one (final) `return` expression

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -19,28 +19,6 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 set_option trace.Meta.debug true
 
 
-
--- TODO: create a snapshot test for the `square_of` inductive relation
-
-inductive square_of : Nat → Nat → Prop where
-  | sq : forall n, square_of n (n * n)
-
-#derive_checker (square_of n m)
-
-/-
-instance : DecOpt (square_of n m) where
-  decOpt :=
-    let rec aux_dec (initSize : Nat) (size : Nat) (n_0 : Nat) (m_0 : Nat) : Option Bool :=
-      match size with
-      | Nat.zero => DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
-      | Nat.succ size' =>
-        DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
-    fun size => aux_dec size size n m
-
--/
-
-
-
 ---
 
 /- Example usage:

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -18,7 +18,7 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 
 set_option trace.Meta.debug true
 
--- #derive_generator (fun (t : Tree) => bst lo hi t)
+-- #derive_checker (typing Γ e τ)
 
 
 ---

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -18,12 +18,26 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 
 set_option trace.Meta.debug true
 
--- TODO: figure out how to rewrite function calls (see section 3 of Computing Correctly)
+
+
+-- TODO: create a snapshot test for the `square_of` inductive relation
 
 inductive square_of : Nat → Nat → Prop where
   | sq : forall n, square_of n (n * n)
 
--- #derive_checker (square_of n m)
+#derive_checker (square_of n m)
+
+/-
+instance : DecOpt (square_of n m) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (n_0 : Nat) (m_0 : Nat) : Option Bool :=
+      match size with
+      | Nat.zero => DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
+    fun size => aux_dec size size n m
+
+-/
 
 
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -16,7 +16,16 @@ open Lean Meta
 open Plausible ArbitrarySizedSuchThat OptionTGen
 
 
+set_option trace.Meta.debug true
+
 -- TODO: figure out how to rewrite function calls (see section 3 of Computing Correctly)
+
+inductive square_of : Nat → Nat → Prop where
+  | sq : forall n, square_of n (n * n)
+
+-- #derive_checker (square_of n m)
+
+
 
 ---
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -18,6 +18,8 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 
 set_option trace.Meta.debug true
 
+-- #derive_generator (fun (t : Tree) => bst lo hi t)
+
 
 ---
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -15,10 +15,7 @@ open Lean Meta
 
 open Plausible ArbitrarySizedSuchThat OptionTGen
 
-
 set_option trace.Meta.debug true
-
--- #derive_checker (typing Γ e τ)
 
 
 ---

--- a/Plausible/New/Utils.lean
+++ b/Plausible/New/Utils.lean
@@ -17,11 +17,6 @@ def hasInstance (className : Name) (type : Expr) : MetaM Bool := do
   let classType ← mkAppM className #[type]
   Option.isSome <$> synthInstance? classType
 
-/-- `containsFuncApp e` returns a boolean indicating whether `e` contains a subterm
-     that is a function application -/
-def containsFuncApp (e : Expr) : Bool :=
-  Option.isSome $ Expr.find? Expr.isApp e
-
 
 /-- Determines if a constructor for an inductive relation is *recursive*
     (i.e. the constructor's type mentions the inductive relation)

--- a/Plausible/New/Utils.lean
+++ b/Plausible/New/Utils.lean
@@ -17,6 +17,11 @@ def hasInstance (className : Name) (type : Expr) : MetaM Bool := do
   let classType ← mkAppM className #[type]
   Option.isSome <$> synthInstance? classType
 
+/-- `containsFuncApp e` returns a boolean indicating whether `e` contains a subterm
+     that is a function application -/
+def containsFuncApp (e : Expr) : Bool :=
+  Option.isSome $ Expr.find? Expr.isApp e
+
 
 /-- Determines if a constructor for an inductive relation is *recursive*
     (i.e. the constructor's type mentions the inductive relation)

--- a/Test.lean
+++ b/Test.lean
@@ -42,4 +42,5 @@ import Test.DeriveDecOpt.DeriveRegExpMatchChecker
 import Test.DeriveDecOpt.NonLinearPatternsTest
 import Test.DeriveDecOpt.SimultaneousMatchingTests
 import Test.DeriveDecOpt.ExistentialVariablesTest
+import Test.DeriveDecOpt.FunctionCallsTest
 import Test.DeriveDecOpt.DeriveSTLCChecker

--- a/Test/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/Test/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -1,5 +1,6 @@
 import Plausible.New.DecOpt
 import Plausible.New.DeriveChecker
+import Plausible.New.EnumeratorCombinators
 import Test.DeriveDecOpt.DeriveBSTChecker
 import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
 
@@ -34,3 +35,53 @@ info: Try this checker: instance : DecOpt (lookup Γ x τ) where
 -/
 #guard_msgs(info, drop warning) in
 #derive_checker (lookup Γ x τ)
+
+-- Dummy `EnumSizedSuchThat` instance
+-- TODO: implement metaprogramming infrastructure for deriving `EnumSizedSuchThat` instances
+instance : EnumSizedSuchThat type (fun τ => typing Γ e τ) where
+  enumSizedST := fun _ => OptionT.fail
+
+/--
+info: Try this checker: instance : DecOpt (typing Γ e τ) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (Γ_0 : List type) (e_0 : term) (τ_0 : type) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match e_0, τ_0 with
+            | term.Const n, type.Nat => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match e_0 with
+            | term.Var x => DecOpt.andOptList [DecOpt.decOpt (lookup Γ x τ) initSize]
+            | _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match e_0, τ_0 with
+            | term.Const n, type.Nat => Option.some Bool.true
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match e_0, τ_0 with
+            | term.Add e1 e2, type.Nat =>
+              DecOpt.andOptList [aux_dec initSize size' Γ e1 type.Nat, aux_dec initSize size' Γ e2 type.Nat]
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match e_0, τ_0 with
+            | term.Abs τ1 e, type.Fun τ1_0 τ2 => DecOpt.andOptList [aux_dec initSize size' (τ1 :: Γ) e τ2]
+            | _, _ => Option.some Bool.false,
+            fun _ =>
+            match e_0 with
+            | term.Var x => DecOpt.andOptList [DecOpt.decOpt (lookup Γ x τ) initSize]
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match e_0 with
+            | term.App (term.Abs type.Nat e1) e2 =>
+              EnumeratorCombinators.enumeratingOpt (EnumSuchThat.enumST (fun τ1 => typing Γ e2 τ1))
+                (fun τ1 => DecOpt.andOptList [aux_dec initSize size' Γ e1 (type.Fun τ1 τ)]) initSize
+            | _ => Option.some Bool.false]
+    fun size => aux_dec size size Γ e τ
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (typing Γ e τ)

--- a/Test/DeriveDecOpt/FunctionCallsTest.lean
+++ b/Test/DeriveDecOpt/FunctionCallsTest.lean
@@ -1,0 +1,25 @@
+import Plausible.New.DecOpt
+import Plausible.New.DeriveChecker
+
+open DecOpt
+
+set_option guard_msgs.diff true
+
+-- Example taken from section 3.1 of "Computing Correctly with Inductive Relations"
+-- Note how `n * n` is a function call that appears in the conclusion of a constructor
+-- for an inductive relation
+inductive square_of : Nat → Nat → Prop where
+  | sq : forall n, square_of n (n * n)
+
+/--
+info: Try this checker: instance : DecOpt (square_of n m) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (n_0 : Nat) (m_0 : Nat) : Option Bool :=
+      match size with
+      | Nat.zero => DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack [fun _ => DecOpt.andOptList [DecOpt.decOpt (@Eq Nat m (n * n)) initSize]]
+    fun size => aux_dec size size n m
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (square_of n m)


### PR DESCRIPTION
This PR allows derived checkers to handle function calls that appear in the conclusion of constructors, for example: 

```lean 
-- Example taken from section 3.1 of "Computing Correctly with Inductive Relations"
-- Note how `n * n` is a function call that appears in the conclusion of a constructor
-- for an inductive relation
inductive square_of : Nat → Nat → Prop where
  | sq : forall n, square_of n (n * n)
```
(This example is in `Test/DeriveDecOpt/FunctionCallsTest.lean`)

To handle this, we create a fresh variable & add an extra hypothesis where the fresh var is bound to the result of the function call. 

This PR also fixes a bug with unbound variables in the continuation passed to `EnumeratorCombinators.enumeratingOpt`, which is invoked by checkers when we need to enumerate existentially quantified variables that satisfy some proposition. 