### PR TITLE
Deriver for Constrained Enumerators (instances of `EnumSizedSuchThat`)

### DIFF
--- a/Plausible/IR/Constructor.lean
+++ b/Plausible/IR/Constructor.lean
@@ -68,6 +68,13 @@ inductive CheckerSort where
   | InductiveChecker
   deriving Repr, BEq
 
+/-- Determines whether a producer is a `Generator` or an `Enumerator` -/
+inductive ProducerType where
+  | Generator
+  | Enumerator
+  deriving Repr, BEq
+
+
 /-- Datatype containing metadata needed to derive a handler
     (handlers are a generalization of sub-generators/sub-checkers)
     - See the `SubGeneratorInfo` & `SubCheckerInfo` types, which extend this type
@@ -94,6 +101,7 @@ structure HandlerInfo where
   /-- A list of equalities that must hold between free variables
       (used when rewriting free variabels in patterns) -/
   variableEqualities : Array (FVarId × FVarId)
+
   deriving Repr
 
 /-- Datatype containing metadata needed to derive a sub-generator
@@ -105,6 +113,10 @@ structure SubGeneratorInfo extends HandlerInfo where
        when `size > 0` (i.e. the sub-generator is inductively defined and makes
        recursive calls) -/
   generatorSort : GeneratorSort
+
+  /-- Determines whether the producer is a generator or an enumerator -/
+  producerType : ProducerType
+
   deriving Repr
 
 /-- Datatype containing metadata needed to derive a sub-checker
@@ -416,6 +428,7 @@ def mkSubGeneratorInfoFromConstructor (ctor : InductiveConstructor) (inputNames 
     groupedActions := groupedActions
     variableEqualities := conclusion.variableEqualities ++ groupedActions.variableEqualities
     generatorSort := generatorSort
+    producerType := .Generator -- TODO: figure out how to generalize this to handle enumerators
   }
 
 /-- Produces the final if-statement that checks the conjunction of all the hypotheses

--- a/Plausible/IR/Renaming.lean
+++ b/Plausible/IR/Renaming.lean
@@ -135,7 +135,8 @@ def testSimpleRenaming : MetaM Unit := do
         variableEqualities := #[]
       },
       generatorSort := .InductiveGenerator,
-      variableEqualities := #[]
+      variableEqualities := #[],
+      producerType := .Generator
     }
 
     logWarning m!"Before renaming - nExpr name: {nExpr}"

--- a/Plausible/New/Chamelean.lean
+++ b/Plausible/New/Chamelean.lean
@@ -20,6 +20,7 @@ import Plausible.New.NKIExperiments
 import Plausible.New.DeriveArbitrary
 import Plausible.New.DeriveEnum
 import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.SubEnumerators
 import Plausible.New.Utils
 import Plausible.New.UnificationMonad
 import Plausible.New.ModeAnalysis

--- a/Plausible/New/Chamelean.lean
+++ b/Plausible/New/Chamelean.lean
@@ -19,6 +19,7 @@ import Plausible.New.Trees
 import Plausible.New.NKIExperiments
 import Plausible.New.DeriveArbitrary
 import Plausible.New.DeriveEnum
+import Plausible.New.DeriveEnumSuchThat
 import Plausible.New.Utils
 import Plausible.New.UnificationMonad
 import Plausible.New.ModeAnalysis

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -51,7 +51,7 @@ def mkTopLevelChecker (baseCheckers : TSyntax `term) (inductiveCheckers : TSynta
   innerParams := innerParams.push initSizeParam
   innerParams := innerParams.push sizeParam
 
-  -- Outer params are for the top-level lambda function which invokes `aux_arb`
+  -- Outer params are for the top-level lambda function which invokes `aux_dec`
   let mut outerParams := #[]
   for (paramName, paramType) in paramInfo do
     let outerParamIdent := mkIdent paramName

--- a/Plausible/New/DeriveEnumSuchThat.lean
+++ b/Plausible/New/DeriveEnumSuchThat.lean
@@ -4,6 +4,7 @@ import Plausible.IR.Prelude
 import Plausible.IR.Constructor
 import Plausible.IR.GCCall
 import Plausible.New.DeriveGenerator
+import Plausible.New.SubEnumerators
 import Plausible.New.Idents
 import Plausible.New.Utils
 
@@ -114,6 +115,7 @@ def elabDeriveEnumerator : CommandElab := fun stx => do
     let baseGenInfo := Array.filter (fun gen => gen.generatorSort == .BaseGenerator) allSubGeneratorInfos
     let inductiveGenInfo := allSubGeneratorInfos
 
+    -- TODO: modify `mkWeightedThunkedSubGenerators` (enumerators don't have weights & aren't thunked)
     let baseEnumerators ← liftTermElabM $ mkWeightedThunkedSubGenerators baseGenInfo .BaseGenerator
     let inductiveEnumerators ← liftTermElabM $ mkWeightedThunkedSubGenerators inductiveGenInfo .InductiveGenerator
 

--- a/Plausible/New/DeriveEnumSuchThat.lean
+++ b/Plausible/New/DeriveEnumSuchThat.lean
@@ -1,0 +1,133 @@
+import Lean
+import Std
+import Plausible.IR.Prelude
+import Plausible.IR.Constructor
+import Plausible.IR.GCCall
+import Plausible.New.DeriveGenerator
+import Plausible.New.Idents
+import Plausible.New.Utils
+
+open Plausible.IR
+open Lean Elab Command Meta Term Parser Std
+open Idents
+
+/-- Produces an instance of the `EnumSizedSuchThat` typeclass containing the definition for the top-level derived enumerator.
+    The arguments to this function are:
+    - a list of `baseEnumerators` (each represented as a Lean term), to be invoked when `size == 0`
+    - a list of `inductiveEnumerators`, to be invoked when `size > 0`
+    - the name of the inductive relation (`inductiveStx`)
+    - the arguments (`args`) to the inductive relation
+    - the name and type for the value we wish to enumerate (`targetVar`, `targetTypeSyntax`) -/
+def mkTopLevelEnumerator (baseEnumerators : TSyntax `term) (inductiveEnumerators : TSyntax `term) (inductiveStx : TSyntax `term)
+  (args : TSyntaxArray `term) (targetVar : Name)
+  (targetTypeSyntax : TSyntax `term) : CommandElabM (TSyntax `command) := do
+    -- Fetch the ambient local context, which we need to produce user-accessible fresh names
+    let localCtx ← liftTermElabM $ getLCtx
+
+    -- Produce a fresh name for the `size` argument for the lambda
+    -- at the end of the enumerator function, as well as the `aux_enum` inner helper function
+    let freshSizeIdent := mkFreshAccessibleIdent localCtx `size
+    let freshSize' := mkFreshAccessibleIdent localCtx `size'
+    let auxEnumIdent := mkFreshAccessibleIdent localCtx `aux_enum
+    let enumeratorType ← `($optionTTypeConstructor $enumTypeConstructor $targetTypeSyntax)
+
+    let inductiveName := inductiveStx.raw.getId
+
+    -- Create the cases for the pattern-match on the size argument
+    let mut caseExprs := #[]
+    let zeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $OptionTBacktrackFn $baseEnumerators)
+    caseExprs := caseExprs.push zeroCase
+
+    let succCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshSize' => $OptionTBacktrackFn $inductiveEnumerators)
+    caseExprs := caseExprs.push succCase
+
+    -- Create function arguments for the enumerator's `size` & `initSize` parameters
+    -- (former is the enumerator size, latter is the size argument with which to invoke other auxiliary enumerators/checkers)
+    let initSizeParam ← `(Term.letIdBinder| ($initSizeIdent : $natIdent))
+    let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
+    let matchExpr ← liftTermElabM $ mkMatchExpr sizeIdent caseExprs
+
+    -- Add parameters for each argument to the inductive relation
+    -- (except the target variable, which we'll filter out later)
+    let paramInfo ← analyzeInductiveArgs inductiveName args
+
+    -- Inner params are for the inner `aux_arb` function
+    let mut innerParams := #[]
+    innerParams := innerParams.push initSizeParam
+    innerParams := innerParams.push sizeParam
+
+    -- Outer params are for the top-level lambda function which invokes `aux_arb`
+    let mut outerParams := #[]
+    for (paramName, paramType) in paramInfo do
+      -- Only add a function parameter is the argument to the inductive relation is not the target variable
+      -- (We skip the target variable since that's the value we wish to generate)
+      if paramName != targetVar then
+        let outerParamIdent := mkIdent paramName
+        outerParams := outerParams.push outerParamIdent
+
+        -- Each parameter to the inner `aux_arb` function needs to be a fresh name
+        -- (so that if we pattern match on the parameter, we avoid pattern variables from shadowing it)
+        let innerParamIdent := mkIdent $ genFreshName (Array.map Prod.fst paramInfo) paramName
+
+        let innerParam ← `(Term.letIdBinder| ($innerParamIdent : $paramType))
+        innerParams := innerParams.push innerParam
+
+    -- Produces an instance of the `EnumSizedSuchThat` typeclass containing the definition for the derived enumerator
+    `(instance : $enumSizedSuchThatTypeclass $targetTypeSyntax (fun $(mkIdent targetVar) => $inductiveStx $args*) where
+        $unqualifiedEnumSizedSTFn:ident :=
+          let rec $auxEnumIdent:ident $innerParams* : $enumeratorType :=
+            $matchExpr
+          fun $freshSizeIdent => $auxEnumIdent $freshSizeIdent $freshSizeIdent $outerParams*)
+
+
+syntax (name := derive_enumerator) "#derive_enumerator" "(" "fun" "(" ident ":" term ")" "=>" term ")" : command
+
+@[command_elab derive_enumerator]
+def elabDeriveEnumerator : CommandElab := fun stx => do
+  match stx with
+  | `(#derive_enumerator ( fun ( $var:ident : $targetTypeSyntax:term ) => $body:term )) => do
+
+    -- Parse the body of the lambda for an application of the inductive relation
+    let (inductiveName, args) ← deconstructInductiveApplication body
+    let targetVar := var.getId
+
+    -- Elaborate the name of the inductive relation and the type
+    -- of the value to be generated
+    let inductiveExpr ← liftTermElabM $ elabTerm inductiveName none
+
+    -- Find the index of the argument in the inductive application for the value we wish to generate
+    -- (i.e. find `i` s.t. `args[i] == targetVar`)
+    let targetIdxOpt := findTargetVarIndex targetVar args
+    if let .none := targetIdxOpt then
+      throwError "cannot find index of value to be generated"
+    let targetIdx := Option.get! targetIdxOpt
+
+    let argNameStrings := convertIdentsToStrings args
+
+    -- Create an auxiliary `SubGeneratorInfo` structure that
+    -- stores the metadata for each derived sub-generator
+    let allSubGeneratorInfos ← liftTermElabM $ getSubGeneratorInfos inductiveExpr argNameStrings targetIdx
+
+    -- Every generator is an inductive generator
+    -- (they can all be invoked in the inductive case of the top-level generator),
+    -- but only certain generators qualify as `BaseGenerator`s
+    let baseGenInfo := Array.filter (fun gen => gen.generatorSort == .BaseGenerator) allSubGeneratorInfos
+    let inductiveGenInfo := allSubGeneratorInfos
+
+    let baseEnumerators ← liftTermElabM $ mkWeightedThunkedSubGenerators baseGenInfo .BaseGenerator
+    let inductiveEnumerators ← liftTermElabM $ mkWeightedThunkedSubGenerators inductiveGenInfo .InductiveGenerator
+
+    let typeclassInstance ← mkTopLevelEnumerator baseEnumerators inductiveEnumerators inductiveName args targetVar targetTypeSyntax
+
+    -- Pretty-print the derived generator
+    let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeclassInstance)
+
+    -- Display the code for the derived generator to the user
+    -- & prompt the user to accept it in the VS Code side panel
+    liftTermElabM $ Tactic.TryThis.addSuggestion stx
+      (Format.pretty genFormat) (header := "Try this generator: ")
+
+    -- Elaborate the typeclass instance and add it to the local context
+    elabCommand typeclassInstance
+
+  | _ => throwUnsupportedSyntax

--- a/Plausible/New/DeriveGenerator.lean
+++ b/Plausible/New/DeriveGenerator.lean
@@ -198,7 +198,7 @@ def elabDeriveGenerator : CommandElab := fun stx => do
 
     -- Create an auxiliary `SubGeneratorInfo` structure that
     -- stores the metadata for each derived sub-generator
-    let allSubGeneratorInfos ← liftTermElabM $ getSubGeneratorInfos inductiveExpr argNameStrings targetIdx
+    let allSubGeneratorInfos ← liftTermElabM $ getSubGeneratorInfos inductiveExpr argNameStrings targetIdx .Generator
 
     -- Every generator is an inductive generator
     -- (they can all be invoked in the inductive case of the top-level generator),

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -30,6 +30,9 @@ def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
 /-- Ident for the `DecOpt.checkerBacktrack` checker combinator (see `DecOpt.lean`) -/
 def checkerBacktrackFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "checkerBacktrack"
 
+/-- Ident for the `EnumeratorCombinators.enumerate` combinator (see `EnumeratorCombinators.lean`) -/
+def enumerateFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "enumerate"
+
 /-- Ident for the `EnumeratorCombinators.enumerating` combinator (see `EnumeratorCombinators.lean`) -/
 def enumeratingFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "enumerating"
 

--- a/Plausible/New/Idents.lean
+++ b/Plausible/New/Idents.lean
@@ -50,6 +50,7 @@ def failFn : Ident := mkIdent $ Name.mkStr2 "OptionT" "fail"
 
 -- Idents for typeclasses
 def arbitrarySizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySizedSuchThat"
+def enumSizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "EnumSizedSuchThat"
 def arbitrarySizedTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySized"
 def enumSizedTypeclass : Ident := mkIdent $ Name.mkStr1 "EnumSized"
 def decOptTypeclass : Ident := mkIdent $ Name.mkStr1 "DecOpt"

--- a/Plausible/New/OptionTGen.lean
+++ b/Plausible/New/OptionTGen.lean
@@ -70,7 +70,7 @@ def sized (f : Nat → OptionT Gen α) : OptionT Gen α :=
   Gen.getSize >>= f
 
 /-- Samples from an `OptionT Gen` generator that is parameterized by its `size`,
-    returning the generated `Option α`  in the `IO` monad -/
+    returning the generated `Option α` in the `IO` monad -/
 def runSizedGen {α} (sizedGen : Nat → OptionT Gen α) (size : Nat) : IO (Option α) :=
   Gen.run (OptionT.run $ sizedGen size) size
 

--- a/Plausible/New/SubEnumerators.lean
+++ b/Plausible/New/SubEnumerators.lean
@@ -1,0 +1,20 @@
+import Lean
+import Plausible.IR.Constructor
+import Plausible.New.Idents
+import Plausible.New.TSyntaxCombinators
+import Plausible.New.SubGenerators
+
+open Plausible.IR
+open Lean Elab Command Meta Term Parser Std
+open Idents
+
+/-- Creates a list of sub-enumerator terms (to be passed to the `enumerate` enumerator combinator) -/
+def mkSubEnumeratorList (subGeneratorInfos : Array SubGeneratorInfo)
+  (generatorSort : GeneratorSort) : TermElabM (TSyntax `term) := do
+
+  let mut subEnumerators ← Array.mapM mkSubGenerator subGeneratorInfos
+
+  if let .BaseGenerator := generatorSort then
+    subEnumerators := subEnumerators.push (← `($failFn))
+
+  `([$subEnumerators,*])

--- a/Plausible/New/SubGenerators.lean
+++ b/Plausible/New/SubGenerators.lean
@@ -162,10 +162,6 @@ def mkSubGenerator (subGenerator : SubGeneratorInfo) : TermElabM (TSyntax `term)
     if let .checkNonInductive predicateExpr := action then
       let ty ← inferType predicateExpr
 
-      -- TODO: check whether `predicateExpr` is a `Prop` or a `Type`
-
-      logWarning m!"predicateExpr {predicateExpr} is in type universe {ty}"
-
       -- Check if the predicate is a `Prop` (i.e. `Sort 0`)
       if ty.isProp then
         -- If yes, add it to our list of hypotheses to check using the `DecOpt` instance
@@ -259,7 +255,8 @@ def getGeneratorWeight (gen : SubGeneratorInfo) : TermElabM (TSyntax `term) := d
   | .InductiveGenerator => `($(mkIdent ``Nat.succ) $(mkIdent `size'))
 
 /-- Constructs a list of weighted thunked sub-generators as a Lean term -/
-def mkWeightedThunkedSubGenerators (subGeneratorInfos : Array SubGeneratorInfo) (generatorSort : GeneratorSort) : TermElabM (TSyntax `term) := do
+def mkWeightedThunkedSubGenerators (subGeneratorInfos : Array SubGeneratorInfo)
+  (generatorSort : GeneratorSort) : TermElabM (TSyntax `term) := do
   let subGenerators ← Array.mapM mkSubGenerator subGeneratorInfos
   let generatorWeights ← Array.mapM getGeneratorWeight subGeneratorInfos
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -9,6 +9,7 @@ import Plausible.New.ArbitrarySizedSuchThat
 import Plausible.New.EnumeratorCombinators
 import Plausible.New.DeriveEnum
 import Plausible.New.DeriveChecker
+import Plausible.New.DeriveEnumSuchThat
 import Plausible.New.STLC
 
 import Lean
@@ -18,27 +19,7 @@ open Plausible ArbitrarySizedSuchThat OptionTGen
 
 deriving instance Enum for Tree
 
-instance : EnumSizedSuchThat Tree (fun t => bst lo hi t) where
-  enumSizedST :=
-   let rec aux_enum (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) : OptionT Enumerator Tree :=
-      match size with
-      | Nat.zero =>
-        EnumeratorCombinators.enumerate
-          [pure .Leaf, OptionT.fail]
-      | Nat.succ size' =>
-        EnumeratorCombinators.enumerate
-          [pure .Leaf,
-            do
-              let x ← Enum.enum
-              let l ← aux_enum initSize size' lo_0 x
-              let r ← aux_enum initSize size' x hi_0
-              if lo < x && x < hi then
-                return Tree.Node x l r
-              else
-                OptionT.fail]
-    fun size => aux_enum size size lo hi
-
-
+-- #derive_enumerator (fun (t : Tree) => bst lo hi t)
 
 
 ---

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -4,6 +4,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.Arbitrary
+import Plausible.New.Enumerators
 import Plausible.New.ArbitrarySizedSuchThat
 import Plausible.New.EnumeratorCombinators
 import Plausible.New.DeriveEnum
@@ -15,7 +16,29 @@ open Lean Meta
 
 open Plausible ArbitrarySizedSuchThat OptionTGen
 
-set_option trace.Meta.debug true
+deriving instance Enum for Tree
+
+instance : EnumSizedSuchThat Tree (fun t => bst lo hi t) where
+  enumSizedST :=
+   let rec aux_enum (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) : OptionT Enumerator Tree :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [pure .Leaf, OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [pure .Leaf,
+            do
+              let x ← Enum.enum
+              let l ← aux_enum initSize size' lo_0 x
+              let r ← aux_enum initSize size' x hi_0
+              if lo < x && x < hi then
+                return Tree.Node x l r
+              else
+                OptionT.fail]
+    fun size => aux_enum size size lo hi
+
+
 
 
 ---

--- a/Plausible/New/Trees.lean
+++ b/Plausible/New/Trees.lean
@@ -1,5 +1,6 @@
 import Plausible.IR.Examples
 import Plausible.New.OptionTGen
+import Plausible.New.Arbitrary
 import Plausible.New.ArbitrarySizedSuchThat
 import Plausible.New.DecOpt
 
@@ -31,7 +32,7 @@ def genBST (lo : Nat) (hi : Nat) : Nat → OptionT Gen Tree :=
       backtrack [
         (1, thunkGen $ fun _ => pure .Leaf),
         (.succ size', thunkGen $ fun _ => do
-          let x ← SampleableExt.interpSample Nat
+          let x ← Arbitrary.arbitrary
           if (lo_0 < x && x < hi_0) then
             let l ← aux_arb initSize size' lo_0 x
             let r ← aux_arb initSize size' x hi_0
@@ -77,7 +78,7 @@ def genBalancedTree (n : Nat) : Nat → OptionT Gen Tree :=
             | .succ n => do
               let l ← aux_arb initSize size' n
               let r ← aux_arb initSize size' n
-              let x ← SampleableExt.interpSample Nat
+              let x ← Arbitrary.arbitrary
               pure (.Node x l r))
         ]
   fun size => aux_arb size size n

--- a/Plausible/New/Utils.lean
+++ b/Plausible/New/Utils.lean
@@ -1,6 +1,7 @@
 
 import Lean
 import Plausible.IR.Prelude
+import Batteries.Data.List.Basic
 
 open Lean Meta
 open Plausible.IR
@@ -42,6 +43,11 @@ def replicateM [Monad m] (n : Nat) (action : m α) : m (List α) :=
     let x ← action
     let xs ← replicateM n action
     pure (x :: xs)
+
+/-- Converts a list of options to an optional list
+    (akin to Haskell's `sequence`) -/
+def List.sequence (xs : List (Option α)) : Option (List α) :=
+  List.traverse id xs
 
 /-- `ToMessageData` instance for pretty-printing `ConstructorVal`s -/
 instance : ToMessageData ConstructorVal where

--- a/README.md
+++ b/README.md
@@ -106,13 +106,17 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 
 **Metaprogramming infrastructure**:
 - [`TSyntaxCombinators.lean`](./Plausible/New/TSyntaxCombinators.lean): Combinators over `TSyntax` for creating monadic `do`-blocks & other Lean expressions via metaprogramming
-- [`DeriveArbitrary.lean`](./Plausible/New/DeriveArbitrary.lean): Metaprogramming infrastructure for deriving unconstrained generators (instances of the `Arbitrary` / `ArbitrarySized` typeclasses)
-- [`DeriveEnum.lean`](./Plausible/New/DeriveEnum.lean): Metaprogramming infrastructure for deriving unconstrainted enumerators 
+- [`DeriveArbitrary.lean`](./Plausible/New/DeriveArbitrary.lean): Deriver for unconstrained generators (instances of the `Arbitrary` / `ArbitrarySized` typeclasses)
+- [`DeriveEnum.lean`](./Plausible/New/DeriveEnum.lean): Deriver for unconstrainted enumerators 
 (instances of the `Enum` / `EnumSized` typeclasses) 
-- [`DeriveGenerator.lean`](./Plausible/New/DeriveGenerator.lean): Metaprogramming infrastructure for deriving *constrained* generators (instances of the `ArbitrarySizedSuchThat` typeclass)
-- [`DeriveChecker.lean`](./Plausible/New/DeriveChecker.lean): Metaprogramming infrastructure for automatically deriving checkers (instances of the `DecOpt` typeclass)
+- [`DeriveGenerator.lean`](./Plausible/New/DeriveGenerator.lean): Deriver for *constrained* generators (instances of the `ArbitrarySizedSuchThat` typeclass)
+- [`DeriveEnumSuchThat.lean`](./Plausible/New/DeriveEnumSuchThat.lean): Deriver for *constrained* enumerators (instances of the `EnumSizedSuchThat` typeclass) 
+- [`DeriveChecker.lean`](./Plausible/New/DeriveChecker.lean): Deriver for automatically deriving checkers (instances of the `DecOpt` typeclass)
+
+**Logic for handling constraints when deriving code**:
 - [`SubGenerators.lean`](./Plausible/New/SubGenerators.lean): Handles constraints when deriving sub-generators (handlers invoked by top-level derived generators)
 - [`SubCheckers.lean`](./Plausible/New/SubCheckers.lean): Handles constraints when deriving sub-checkers (handlers invoked by top-level derived checkers)
+- [`SubEnumerators.lean`](./Plausible/New/SubEnumerators.lean): Handles constraints when deriving sub-enumerators (handlers invoked by top-level derived enumerators)
 
 **Miscellany**:
 - [`LazyList.lean`](./Plausible/New/LazyList.lean): Implementation of lazy lists (used for enumerators)

--- a/Test.lean
+++ b/Test.lean
@@ -44,3 +44,11 @@ import Test.DeriveDecOpt.SimultaneousMatchingTests
 import Test.DeriveDecOpt.ExistentialVariablesTest
 import Test.DeriveDecOpt.FunctionCallsTest
 import Test.DeriveDecOpt.DeriveSTLCChecker
+
+-- Tests for `#derive_enumerator` (derives `EnumSuchThat`)
+import Test.DeriveEnumSuchThat.DeriveBSTEnumerator
+import Test.DeriveEnumSuchThat.DeriveBalancedTreeEnumerator
+import Test.DeriveEnumSuchThat.DeriveRegExpMatchEnumerator
+import Test.DeriveEnumSuchThat.DeriveSTLCEnumerator
+import Test.DeriveEnumSuchThat.SimultaneousMatchingTests
+import Test.DeriveEnumSuchThat.NonLinearPatternsTest

--- a/Test/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
@@ -1,0 +1,28 @@
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat BinaryTree (fun t => BST lo hi t) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (lo_0 : Nat) (hi_0 : Nat) : OptionT Enumerator BinaryTree :=
+      match size with
+      | Nat.zero => EnumeratorCombinators.enumerate [pure BinaryTree.Leaf, OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [pure BinaryTree.Leaf, do
+            let x ← Enum.enum
+            let l ← aux_enum initSize size' lo x
+            let r ← aux_enum initSize size' x hi
+            if lo < x && x < hi then ⏎
+              return BinaryTree.Node x l r
+            else
+              OptionT.fail]
+    fun size => aux_enum size size lo hi
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (t : BinaryTree) => BST lo hi t)

--- a/Test/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
@@ -1,0 +1,43 @@
+
+import Plausible.New.OptionTGen
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat BinaryTree (fun t => balancedTree n t) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (n_0 : Nat) : OptionT Enumerator BinaryTree :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match n_0 with
+            | 0 => pure BinaryTree.Leaf
+            | _ => OptionT.fail,
+            match n_0 with
+            | 1 => pure BinaryTree.Leaf
+            | _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match n_0 with
+            | 0 => pure BinaryTree.Leaf
+            | _ => OptionT.fail,
+            match n_0 with
+            | 1 => pure BinaryTree.Leaf
+            | _ => OptionT.fail,
+            match n_0 with
+            | Nat.succ n => do
+              let l ← aux_enum initSize size' n
+              let r ← aux_enum initSize size' n
+              let x ← Enum.enum
+              return BinaryTree.Node x l r
+            | _ => OptionT.fail]
+    fun size => aux_enum size size n
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (t : BinaryTree) => balancedTree n t)

--- a/Test/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
@@ -1,0 +1,65 @@
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat (List Nat) (fun s => ExpMatch s r0) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (r0_0 : RegExp) : OptionT Enumerator (List Nat) :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match r0_0 with
+            | RegExp.EmptyStr => pure []
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Char x => pure [x]
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Star re => pure []
+            | _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match r0_0 with
+            | RegExp.EmptyStr => pure []
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Char x => pure [x]
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.App re1 re2 => do
+              let s1 ← aux_enum initSize size' re1
+              let s2 ← aux_enum initSize size' re2
+              return s1 ++ s2
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Union re1 re2 => do
+              let s ← aux_enum initSize size' re1
+              return s
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Union re1 re2 => do
+              let s ← aux_enum initSize size' re2
+              return s
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Star re => pure []
+            | _ => OptionT.fail,
+            match r0_0 with
+            | RegExp.Star re => do
+              let s1 ← aux_enum initSize size' re
+              let s2 ← aux_enum initSize size' (RegExp.Star re)
+              return s1 ++ s2
+            | _ => OptionT.fail]
+    fun size => aux_enum size size r0
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (s : List Nat) => ExpMatch s r0)
+
+-- To sample from this enumerator, we can run the following:
+-- #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun s => ExpMatch s r0)) 3

--- a/Test/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
@@ -1,0 +1,41 @@
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+
+
+set_option guard_msgs.diff true
+
+-- TODO: investigate why `τ'` and not `τ` is appearing as the head of the list in the final pattern-match
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat Nat (fun x => lookup Γ x τ) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (Γ_0 : List type) (τ_0 : type) : OptionT Enumerator Nat :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match Γ_0 with
+            | τ :: Γ =>
+              match DecOpt.decOpt (τ = τ_0) initSize with
+              | Option.some Bool.true => pure 0
+              | _ => OptionT.fail
+            | _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match Γ_0 with
+            | τ :: Γ =>
+              match DecOpt.decOpt (τ = τ_0) initSize with
+              | Option.some Bool.true => pure 0
+              | _ => OptionT.fail
+            | _ => OptionT.fail,
+            match Γ_0 with
+            | τ' :: Γ => do
+              let n ← aux_enum initSize size' Γ τ
+              return Nat.succ n
+            | _ => OptionT.fail]
+    fun size => aux_enum size size Γ τ
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (x : Nat) => lookup Γ x τ)

--- a/Test/DeriveEnumSuchThat/NonLinearPatternsTest.lean
+++ b/Test/DeriveEnumSuchThat/NonLinearPatternsTest.lean
@@ -1,0 +1,34 @@
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+import Test.DeriveEnumSuchThat.DeriveBSTEnumerator
+
+-- See `Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean` for the definition of the inductive relations
+import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
+
+set_option guard_msgs.diff true
+
+-- TODO: (fix this)
+-- we want to invoke `in2_0 = in1_0` in the enumerator, not `in1 = in1_0`!
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat BinaryTree (fun t => GoodTree in1 in2 t) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (in1_0 : Nat) (in2_0 : Nat) : OptionT Enumerator BinaryTree :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match DecOpt.decOpt (in1 = in1_0) initSize with
+            | Option.some Bool.true => pure BinaryTree.Leaf
+            | _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match DecOpt.decOpt (in1 = in1_0) initSize with
+            | Option.some Bool.true => pure BinaryTree.Leaf
+            | _ => OptionT.fail]
+    fun size => aux_enum size size in1 in2
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (t : BinaryTree) => GoodTree in1 in2 t)

--- a/Test/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
+++ b/Test/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
@@ -1,0 +1,67 @@
+import Plausible.New.DecOpt
+import Plausible.New.Enumerators
+import Plausible.New.DeriveEnumSuchThat
+import Plausible.New.EnumeratorCombinators
+
+-- See `Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean` for the definition of the inductive relations
+import Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests
+
+set_option guard_msgs.diff true
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat (List Nat) (fun l => MinOk l a) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (a_0 : List Nat) : OptionT Enumerator (List Nat) :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match a_0 with
+            | [] => pure []
+            | _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match a_0 with
+            | [] => pure []
+            | _ => OptionT.fail,
+            match a_0 with
+            | x :: l' => do
+              let l ← aux_enum initSize size' l'
+              if x ∈ l then ⏎
+                return l
+              else
+                OptionT.fail
+            | _ => OptionT.fail]
+    fun size => aux_enum size size a
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (l: List Nat) => MinOk l a)
+
+/--
+info: Try this generator: instance : EnumSizedSuchThat (List Nat) (fun l => MinEx n l a) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (n_0 : Nat) (a_0 : List Nat) : OptionT Enumerator (List Nat) :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match n_0, a_0 with
+            | 0, [] => pure []
+            | _, _ => OptionT.fail,
+            OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match n_0, a_0 with
+            | 0, [] => pure []
+            | _, _ => OptionT.fail,
+            match n_0, a_0 with
+            | Nat.succ n, x :: l' => do
+              let l ← aux_enum initSize size' n l'
+              if x ∈ l then ⏎
+                return l
+              else
+                OptionT.fail
+            | _, _ => OptionT.fail]
+    fun size => aux_enum size size n a
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (l: List Nat) => MinEx n l a)


### PR DESCRIPTION
This PR adds support for deriving constrained enumerators (which only produce values that satisfy some inductive relation), similar to the existing deriver for constrained generators.

We provide a command elaborator which elaborates the #derive_enumerator command:

```lean
-- `#derive_enumerator` derives a enumerator which produces random trees satisfying the inductive proposition `balanced` 
#derive_enumerator (fun (t : Tree) => balanced n t)
```