### PR TITLE
Refactor: Generalize Metaprogramming Infra to Support Both Constrained Generators & Enumerators 

### DIFF
--- a/Plausible/NKI/TypeCheck.lean
+++ b/Plausible/NKI/TypeCheck.lean
@@ -6,7 +6,7 @@ Authors: Paul Mure
 import Plausible.NKI.Basic
 import Plausible.NKI.Types
 import Plausible.IR.PlausibleIR
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 
 namespace Plausible.NKI
 

--- a/Plausible/New/Chamelean.lean
+++ b/Plausible/New/Chamelean.lean
@@ -1,7 +1,7 @@
 import Plausible.New.DeriveChecker
 import Plausible.New.SubGenerators
 import Plausible.New.SubCheckers
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 import Plausible.New.Tests
 import Plausible.New.OptionTGen
 import Plausible.New.Idents
@@ -10,6 +10,7 @@ import Plausible.New.TSyntaxCombinators
 import Plausible.New.DecOpt
 import Plausible.New.GeneratorCombinators
 import Plausible.New.ArbitrarySizedSuchThat
+import Plausible.New.DeriveArbitrarySuchThat
 import Plausible.New.Arbitrary
 import Plausible.New.Enumerators
 import Plausible.New.EnumeratorCombinators

--- a/Plausible/New/Chase.lean
+++ b/Plausible/New/Chase.lean
@@ -1,4 +1,4 @@
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 import Plausible.New.GenSizedSuchThat
 
 inductive MinOk : List Nat → List Nat → Prop where

--- a/Plausible/New/DeriveChecker.lean
+++ b/Plausible/New/DeriveChecker.lean
@@ -1,6 +1,6 @@
 import Lean
 import Plausible.IR.Prelude
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 import Plausible.New.SubCheckers
 import Plausible.New.Idents
 import Plausible.New.DecOpt

--- a/Plausible/New/NKIExperiments.lean
+++ b/Plausible/New/NKIExperiments.lean
@@ -3,7 +3,7 @@ import Plausible.New.GeneratorCombinators
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
 import Plausible.New.Arbitrary
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 
 open GeneratorCombinators
 

--- a/Plausible/New/Tests.lean
+++ b/Plausible/New/Tests.lean
@@ -1,4 +1,4 @@
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveConstrainedProducers
 import Plausible.Gen
 
 import Plausible.New.OptionTGen

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We provide a command elaborator which elaborates the `#derive_generator` command
 -- `#derive_generator` derives a constrained generator for `Tree`s that are balanced at some height `n`,
 -- where `balanced n t` is a user-defined inductive relation
 #derive_generator (fun (t : Tree) => balanced n t) 
-``
+```
 
 To sample from the derived generator, users invoke `runSizedGen` & specify the right 
 instance of the `ArbitrarySizedSuchThat` typeclass (along with some `Nat` to act as the generator size):

--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`DeriveArbitrary.lean`](./Plausible/New/DeriveArbitrary.lean): Deriver for unconstrained generators (instances of the `Arbitrary` / `ArbitrarySized` typeclasses)
 - [`DeriveEnum.lean`](./Plausible/New/DeriveEnum.lean): Deriver for unconstrainted enumerators 
 (instances of the `Enum` / `EnumSized` typeclasses) 
-- [`DeriveGenerator.lean`](./Plausible/New/DeriveGenerator.lean): Deriver for *constrained* generators (instances of the `ArbitrarySizedSuchThat` typeclass)
-- [`DeriveEnumSuchThat.lean`](./Plausible/New/DeriveEnumSuchThat.lean): Deriver for *constrained* enumerators (instances of the `EnumSizedSuchThat` typeclass) 
+- [`DeriveConstrainedProducers.lean`](./Plausible/New/DeriveConstrainedProducers.lean): Contains most of the generalized logic for deriving constrained producers (used for both generators & enumerators)
+- [`DeriveGenerator.lean`](./Plausible/New/DeriveGenerator.lean): Top-level command elaborator for deriving for *constrained* generators (instances of the `ArbitrarySizedSuchThat` typeclass)
+- [`DeriveEnumSuchThat.lean`](./Plausible/New/DeriveEnumSuchThat.lean): Top-level command elaborator for deriving *constrained* enumerators (instances of the `EnumSizedSuchThat` typeclass) 
 - [`DeriveChecker.lean`](./Plausible/New/DeriveChecker.lean): Deriver for automatically deriving checkers (instances of the `DecOpt` typeclass)
 
 **Logic for handling constraints when deriving code**:

--- a/Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
@@ -3,7 +3,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 
 open ArbitrarySizedSuchThat OptionTGen
 

--- a/Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
@@ -3,7 +3,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 
 open ArbitrarySizedSuchThat OptionTGen

--- a/Test/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
@@ -2,7 +2,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 import Test.DeriveArbitrary.DeriveRegExpGenerator
 
 open ArbitrarySizedSuchThat OptionTGen

--- a/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
@@ -2,7 +2,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 
 open ArbitrarySizedSuchThat OptionTGen
 

--- a/Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
@@ -3,7 +3,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 
 open ArbitrarySizedSuchThat OptionTGen

--- a/Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
+++ b/Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
@@ -3,7 +3,7 @@ import Plausible.Gen
 import Plausible.New.OptionTGen
 import Plausible.New.DecOpt
 import Plausible.New.ArbitrarySizedSuchThat
-import Plausible.New.DeriveGenerator
+import Plausible.New.DeriveArbitrarySuchThat
 
 open ArbitrarySizedSuchThat OptionTGen
 


### PR DESCRIPTION
To minimize code duplication, most of the core logic for deriving both `ArbitrarySizedSuchThat` & `EnumSizedSuchThat` is now located in `DeriveConstrainedProducers.lean`. 

`DeriveArbitrarySuchThat.lean` & `DeriveEnumSuchThat.lean` now only contain the top-level command elaborator declarations. 