### PR TITLE
Compare root namespaces when rewriting function applications

### DIFF
--- a/Plausible/IR/Extractor.lean
+++ b/Plausible/IR/Extractor.lean
@@ -28,7 +28,7 @@ def containsNonTrivialFuncApp (e : Expr) (inductiveRelationName : Name) : MetaM 
       let fn := subExpr.getAppFn
       if fn.isConst then
         let constName := fn.constName!
-        if constName.getRoot != inductiveRelationName then do
+        if constName.getRoot != inductiveRelationName.getRoot then do
           let info ← getConstInfo constName
           return !info.isCtor
         else
@@ -382,7 +382,7 @@ def processConstructorUnifyArgs (ctorName : Name) (ctorType: Expr) (inputVars : 
 
     let conclusion_args := conclusion.getAppArgs
     let final_arg_in_conclusion ← Option.getDM (conclusion_args.toList.getLast?)
-      (throwError "conclusion_args is an unexpected empty list")
+      (throwError m!"conclusion_args is an unexpected empty list, conclusion = {conclusion}, originalConclusion = {originalConclusion}")
 
     for hyp in hypotheses do
       if ← isHypothesisOfInductiveConstructor_inNamespace hyp inductiveRelationName.getRoot then


### PR DESCRIPTION
Small fix: When detecting whether the conclusion of a constructor (for an inductive relation) containing a non-trivial function application (i.e. an application where the function isn't a constructor of some inductive type), compare the root namespaces of the function & the inductive relation being targeted by the generator. 

(This is a temporary fix as we migrate towards using the unification algorithm from Generating Good Generators + the generator schedules in Testing Theorems, see #23.) 