### PR TITLE
Add list permutation snapshot test

### DIFF
--- a/Test.lean
+++ b/Test.lean
@@ -19,6 +19,7 @@ import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
 import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
 import Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests
 import Test.DeriveArbitrarySuchThat.FunctionCallsTest
+import Test.DeriveArbitrarySuchThat.DerivePermutationGenerator
 
 -- Tests for `deriving Arbitrary`
 import Test.DeriveArbitrary.DeriveTreeGenerator

--- a/Test.lean
+++ b/Test.lean
@@ -6,6 +6,13 @@ Authors: Henrik Böving
 -- import Test.Tactic
 -- import Test.Testable
 
+-- Common definitions for snapshot tests
+import Test.CommonDefinitions.BinaryTree
+import Test.CommonDefinitions.FunctionCallInConclusion
+import Test.CommonDefinitions.ListRelations
+import Test.CommonDefinitions.Permutation
+import Test.CommonDefinitions.STLCDefinitions
+
 -- Tests for `#derive_generator` (derives `ArbitrarySuchThat`)
 import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
@@ -48,6 +55,7 @@ import Test.DeriveDecOpt.ExistentialVariablesTest
 import Test.DeriveDecOpt.FunctionCallsTest
 import Test.DeriveDecOpt.DeriveSTLCChecker
 import Test.DeriveDecOpt.NonLinearPatternsTest
+import Test.DeriveDecOpt.DerivePermutationChecker
 
 -- Tests for `#derive_enumerator` (derives `EnumSuchThat`)
 import Test.DeriveEnumSuchThat.DeriveBSTEnumerator

--- a/Test.lean
+++ b/Test.lean
@@ -23,6 +23,9 @@ import Test.DeriveArbitrary.StructureTest
 import Test.DeriveArbitrary.BitVecStructureTest
 import Test.DeriveArbitrarySuchThat.DeriveSTLCGenerator
 import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
+import Test.DeriveArbitrary.MissingNonRecursiveConstructorTest
+import Test.DeriveArbitrary.ParameterizedTypeTest
+import Test.DeriveArbitrary.MutuallyRecursiveTypeTest
 
 -- Tests for instances of `Enum` for simple types
 import Test.Enum.EnumInstancesTest
@@ -53,6 +56,4 @@ import Test.DeriveEnumSuchThat.DeriveRegExpMatchEnumerator
 import Test.DeriveEnumSuchThat.SimultaneousMatchingTests
 import Test.DeriveEnumSuchThat.DeriveSTLCEnumerator
 import Test.DeriveEnumSuchThat.NonLinearPatternsTest
-import Test.DeriveArbitrary.MissingNonRecursiveConstructorTest
-import Test.DeriveArbitrary.ParameterizedTypeTest
-import Test.DeriveArbitrary.MutuallyRecursiveTypeTest
+import Test.DeriveEnumSuchThat.DerivePermutationEnumerator

--- a/Test/CommonDefinitions/Permutation.lean
+++ b/Test/CommonDefinitions/Permutation.lean
@@ -1,0 +1,13 @@
+/-- Inductive relation specifying what it means for two lists to be permutations of each other.
+    - Adapted from https://softwarefoundations.cis.upenn.edu/vfa-1.4/Perm.html -/
+inductive Permutation : List Nat → List Nat → Prop where
+  | PermNil : Permutation [] []
+  | PermSkip : ∀ (x : Nat) (l l' : List Nat),
+               Permutation l l' →
+               Permutation (x :: l) (x :: l')
+  | PermSwap : ∀ (x y : Nat) (l : List Nat),
+              Permutation (y :: x :: l) (x :: y :: l)
+  | PermTrans : ∀ (l l' l'' : List Nat),
+                Permutation l l' →
+                Permutation l' l'' →
+                Permutation l l''

--- a/Test/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
@@ -1,0 +1,85 @@
+import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Chamelean.ArbitrarySizedSuchThat
+import Test.CommonDefinitions.Permutation
+
+/--
+info: Try this generator: instance : ArbitrarySizedSuchThat (List Nat) (fun l_1 => Permutation l_1 l'_1) where
+  arbitrarySizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) (l'_1 : List Nat) : OptionT Plausible.Gen (List Nat) :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1,
+              match l'_1 with
+              | List.nil => return List.nil
+              | _ => OptionT.fail),
+            (1,
+              match l'_1 with
+              | List.cons x (List.cons y l) => return List.cons y (List.cons x l)
+              | _ => OptionT.fail)]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1,
+              match l'_1 with
+              | List.nil => return List.nil
+              | _ => OptionT.fail),
+            (1,
+              match l'_1 with
+              | List.cons x (List.cons y l) => return List.cons y (List.cons x l)
+              | _ => OptionT.fail),
+            (Nat.succ size',
+              match l'_1 with
+              | List.cons x l' => do
+                let l ← aux_arb initSize size' l';
+                return List.cons x l
+              | _ => OptionT.fail),
+            (Nat.succ size', do
+              let l' ← aux_arb initSize size' l'_1;
+              do
+                let l_1 ← aux_arb initSize size' l';
+                return l_1)]
+    fun size => aux_arb size size l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (l : List Nat) => Permutation l l')
+
+/--
+info: Try this generator: instance : ArbitrarySizedSuchThat (List Nat) (fun l_1 => Permutation l'_1 l_1) where
+  arbitrarySizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) (l'_1 : List Nat) : OptionT Plausible.Gen (List Nat) :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1,
+              match l'_1 with
+              | List.nil => return List.nil
+              | _ => OptionT.fail),
+            (1,
+              match l'_1 with
+              | List.cons y (List.cons x l) => return List.cons x (List.cons y l)
+              | _ => OptionT.fail)]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1,
+              match l'_1 with
+              | List.nil => return List.nil
+              | _ => OptionT.fail),
+            (1,
+              match l'_1 with
+              | List.cons y (List.cons x l) => return List.cons x (List.cons y l)
+              | _ => OptionT.fail),
+            (Nat.succ size',
+              match l'_1 with
+              | List.cons x l => do
+                let l' ← aux_arb initSize size' l;
+                return List.cons x l'
+              | _ => OptionT.fail),
+            (Nat.succ size', do
+              let l' ← aux_arb initSize size' l'_1;
+              do
+                let l_1 ← aux_arb initSize size' l';
+                return l_1)]
+    fun size => aux_arb size size l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (l : List Nat) => Permutation l' l)

--- a/Test/DeriveDecOpt/DerivePermutationChecker.lean
+++ b/Test/DeriveDecOpt/DerivePermutationChecker.lean
@@ -1,0 +1,63 @@
+import Plausible.Chamelean.DeriveChecker
+import Plausible.Chamelean.EnumeratorCombinators
+import Test.CommonDefinitions.Permutation
+import Test.DeriveEnumSuchThat.DerivePermutationEnumerator
+
+
+/--
+info: Try this checker: instance : DecOpt (Permutation l_1 l'_1) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (l_1 : List Nat) (l'_1 : List Nat) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l'_1 with
+            | List.nil =>
+              match l_1 with
+              | List.nil => Option.some Bool.true
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 (List.cons u_3 u_4) =>
+              match l_1 with
+              | List.cons y (List.cons x l) =>
+                DecOpt.andOptList
+                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
+                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l'_1 with
+            | List.nil =>
+              match l_1 with
+              | List.nil => Option.some Bool.true
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 (List.cons u_3 u_4) =>
+              match l_1 with
+              | List.cons y (List.cons x l) =>
+                DecOpt.andOptList
+                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
+                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 l' =>
+              match l_1 with
+              | List.cons x l => DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_2 x) initSize, aux_dec initSize size' l l']
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l_1 l') initSize)
+              (fun l' => aux_dec initSize size' l' l'_1) initSize]
+    fun size => aux_dec size size l_1 l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (Permutation l l')

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -1,0 +1,153 @@
+import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Chamelean.DeriveChecker
+import Plausible.Chamelean.EnumeratorCombinators
+
+/-- Inductive relation specifying what it means for two lists to be permutations of each other.
+    - Adapted from https://softwarefoundations.cis.upenn.edu/vfa-1.4/Perm.html -/
+inductive Permutation : List Nat → List Nat → Prop where
+  | PermNil : Permutation [] []
+  | PermSkip : ∀ (x : Nat) (l l' : List Nat),
+               Permutation l l' →
+               Permutation (x :: l) (x :: l')
+  | PermSwap : ∀  (x y : Nat) (l : List Nat),
+              Permutation (y :: x :: l) (x :: y :: l)
+  | PermTrans : ∀  (l l' l'' : List Nat),
+                Permutation l l' →
+                Permutation l' l'' →
+                Permutation l l''
+
+/--
+info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => Permutation l_1 l'_1) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (l'_1 : List Nat) : OptionT Enumerator (List Nat) :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match l'_1 with
+            | List.nil => return List.nil
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons x (List.cons y l) => return List.cons y (List.cons x l)
+            | _ => OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match l'_1 with
+            | List.nil => return List.nil
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons x (List.cons y l) => return List.cons y (List.cons x l)
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons x l' => do
+              let l ← aux_enum initSize size' l';
+              return List.cons x l
+            | _ => OptionT.fail,
+            do
+            let l' ← aux_enum initSize size' l'_1;
+            do
+              let l_1 ← aux_enum initSize size' l';
+              return l_1]
+    fun size => aux_enum size size l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (l : List Nat) => Permutation l l')
+
+/--
+info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => Permutation l'_1 l_1) where
+  enumSizedST :=
+    let rec aux_enum (initSize : Nat) (size : Nat) (l'_1 : List Nat) : OptionT Enumerator (List Nat) :=
+      match size with
+      | Nat.zero =>
+        EnumeratorCombinators.enumerate
+          [match l'_1 with
+            | List.nil => return List.nil
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons y (List.cons x l) => return List.cons x (List.cons y l)
+            | _ => OptionT.fail]
+      | Nat.succ size' =>
+        EnumeratorCombinators.enumerate
+          [match l'_1 with
+            | List.nil => return List.nil
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons y (List.cons x l) => return List.cons x (List.cons y l)
+            | _ => OptionT.fail,
+            match l'_1 with
+            | List.cons x l => do
+              let l' ← aux_enum initSize size' l;
+              return List.cons x l'
+            | _ => OptionT.fail,
+            do
+            let l' ← aux_enum initSize size' l'_1;
+            do
+              let l_1 ← aux_enum initSize size' l';
+              return l_1]
+    fun size => aux_enum size size l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_enumerator (fun (l : List Nat) => Permutation l' l)
+
+
+/--
+info: Try this checker: instance : DecOpt (Permutation l_1 l'_1) where
+  decOpt :=
+    let rec aux_dec (initSize : Nat) (size : Nat) (l_1 : List Nat) (l'_1 : List Nat) : Option Bool :=
+      match size with
+      | Nat.zero =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l'_1 with
+            | List.nil =>
+              match l_1 with
+              | List.nil => Option.some Bool.true
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 (List.cons u_3 u_4) =>
+              match l_1 with
+              | List.cons y (List.cons x l) =>
+                DecOpt.andOptList
+                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
+                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false]
+      | Nat.succ size' =>
+        DecOpt.checkerBacktrack
+          [fun _ =>
+            match l'_1 with
+            | List.nil =>
+              match l_1 with
+              | List.nil => Option.some Bool.true
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 (List.cons u_3 u_4) =>
+              match l_1 with
+              | List.cons y (List.cons x l) =>
+                DecOpt.andOptList
+                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
+                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            match l'_1 with
+            | List.cons u_2 l' =>
+              match l_1 with
+              | List.cons x l => DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_2 x) initSize, aux_dec initSize size' l l']
+              | _ => Option.some Bool.false
+            | _ => Option.some Bool.false,
+            fun _ =>
+            EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l_1 l') initSize)
+              (fun l' => aux_dec initSize size' l' l'_1) initSize]
+    fun size => aux_dec size size l_1 l'_1
+-/
+#guard_msgs(info, drop warning) in
+#derive_checker (Permutation l l')
+
+-- def l := [1, 2, 3]
+-- def l' := [2, 1, 5]
+
+-- #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 1

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -1,20 +1,7 @@
 import Plausible.Chamelean.DeriveConstrainedProducer
-import Plausible.Chamelean.DeriveChecker
 import Plausible.Chamelean.EnumeratorCombinators
+import Test.CommonDefinitions.Permutation
 
-/-- Inductive relation specifying what it means for two lists to be permutations of each other.
-    - Adapted from https://softwarefoundations.cis.upenn.edu/vfa-1.4/Perm.html -/
-inductive Permutation : List Nat → List Nat → Prop where
-  | PermNil : Permutation [] []
-  | PermSkip : ∀ (x : Nat) (l l' : List Nat),
-               Permutation l l' →
-               Permutation (x :: l) (x :: l')
-  | PermSwap : ∀  (x y : Nat) (l : List Nat),
-              Permutation (y :: x :: l) (x :: y :: l)
-  | PermTrans : ∀  (l l' l'' : List Nat),
-                Permutation l l' →
-                Permutation l' l'' →
-                Permutation l l''
 
 /--
 info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => Permutation l_1 l'_1) where
@@ -87,65 +74,6 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 -/
 #guard_msgs(info, drop warning) in
 #derive_enumerator (fun (l : List Nat) => Permutation l' l)
-
-
-/--
-info: Try this checker: instance : DecOpt (Permutation l_1 l'_1) where
-  decOpt :=
-    let rec aux_dec (initSize : Nat) (size : Nat) (l_1 : List Nat) (l'_1 : List Nat) : Option Bool :=
-      match size with
-      | Nat.zero =>
-        DecOpt.checkerBacktrack
-          [fun _ =>
-            match l'_1 with
-            | List.nil =>
-              match l_1 with
-              | List.nil => Option.some Bool.true
-              | _ => Option.some Bool.false
-            | _ => Option.some Bool.false,
-            fun _ =>
-            match l'_1 with
-            | List.cons u_2 (List.cons u_3 u_4) =>
-              match l_1 with
-              | List.cons y (List.cons x l) =>
-                DecOpt.andOptList
-                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
-                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
-              | _ => Option.some Bool.false
-            | _ => Option.some Bool.false]
-      | Nat.succ size' =>
-        DecOpt.checkerBacktrack
-          [fun _ =>
-            match l'_1 with
-            | List.nil =>
-              match l_1 with
-              | List.nil => Option.some Bool.true
-              | _ => Option.some Bool.false
-            | _ => Option.some Bool.false,
-            fun _ =>
-            match l'_1 with
-            | List.cons u_2 (List.cons u_3 u_4) =>
-              match l_1 with
-              | List.cons y (List.cons x l) =>
-                DecOpt.andOptList
-                  [DecOpt.decOpt (BEq.beq u_2 x) initSize,
-                    DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_4 l) initSize, DecOpt.decOpt (BEq.beq u_3 y) initSize]]
-              | _ => Option.some Bool.false
-            | _ => Option.some Bool.false,
-            fun _ =>
-            match l'_1 with
-            | List.cons u_2 l' =>
-              match l_1 with
-              | List.cons x l => DecOpt.andOptList [DecOpt.decOpt (BEq.beq u_2 x) initSize, aux_dec initSize size' l l']
-              | _ => Option.some Bool.false
-            | _ => Option.some Bool.false,
-            fun _ =>
-            EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l_1 l') initSize)
-              (fun l' => aux_dec initSize size' l' l'_1) initSize]
-    fun size => aux_dec size size l_1 l'_1
--/
-#guard_msgs(info, drop warning) in
-#derive_checker (Permutation l l')
 
 -- def l := [1, 2, 3]
 -- def l' := [2, 1, 5]

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -74,8 +74,3 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 -/
 #guard_msgs(info, drop warning) in
 #derive_enumerator (fun (l : List Nat) => Permutation l' l)
-
--- def l := [1, 2, 3]
--- def l' := [2, 1, 5]
-
--- #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 1


### PR DESCRIPTION
This PR adds a snapshot test for checkers/generators/enumerators derived from the following `Permutation` inductive relation (discussed in my internship slides):

```lean
/-- Inductive relation specifying what it means for two lists to be permutations of each other.
    - Adapted from https://softwarefoundations.cis.upenn.edu/vfa-1.4/Perm.html -/
inductive Permutation : List Nat → List Nat → Prop where
  | PermNil : Permutation [] []
  | PermSkip : ∀ (x : Nat) (l l' : List Nat),
               Permutation l l' →
               Permutation (x :: l) (x :: l')
  | PermSwap : ∀ (x y : Nat) (l : List Nat),
              Permutation (y :: x :: l) (x :: y :: l)
  | PermTrans : ∀ (l l' l'' : List Nat),
                Permutation l l' →
                Permutation l' l'' →
                Permutation l l''
```