### PR TITLE
Miscellaneous fixes to enumerators

### DIFF
--- a/Plausible/Chamelean/EnumeratorCombinators.lean
+++ b/Plausible/Chamelean/EnumeratorCombinators.lean
@@ -36,7 +36,7 @@ def enumerateFuel (fuel : Nat) (total : Nat) (es : List (OptionT Enumerator α))
 /-- Tries all enumerators from a list until one returns a `Some` value or all the enumerators have
     failed once with `None`. -/
 def enumerate (es : List (OptionT Enumerator α)) : OptionT Enumerator α :=
-  enumerateFuel es.length es.length es
+  enumerateFuel (fuel := min es.length 10) (total := es.length) es
 
 /-- Applies the checker `f` to a `LazyList l` of values, returning the resultant `Option Bool`
     (the parameter `anyNone` is used to indicate whether any of the elements examined previously have been `none`) -/

--- a/Plausible/Chamelean/EnumeratorCombinators.lean
+++ b/Plausible/Chamelean/EnumeratorCombinators.lean
@@ -38,15 +38,6 @@ def enumerateFuel (fuel : Nat) (total : Nat) (es : List (OptionT Enumerator α))
 def enumerate (es : List (OptionT Enumerator α)) : OptionT Enumerator α :=
   enumerateFuel es.length es.length es
 
-/-- Picks one of the enumerators in `es`, returning the `default` enumerator
-    if `es` is empty. -/
-def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
-  match es with
-  | [] => default
-  | _ => do
-    let idx ← enumNatRange 0 (es.length - 1)
-    List.getD es idx default
-
 /-- Applies the checker `f` to a `LazyList l` of values, returning the resultant `Option Bool`
     (the parameter `anyNone` is used to indicate whether any of the elements examined previously have been `none`) -/
 def lazyListBacktrack (l : LazyList α) (f : α → Option Bool) (anyNone : Bool) : Option Bool :=

--- a/Plausible/Chamelean/Enumerators.lean
+++ b/Plausible/Chamelean/Enumerators.lean
@@ -161,16 +161,15 @@ instance : Enum (BitVec w) where
 
 -- Sampling from enumerators
 
-/-- Returns the list of elements produced by the enumerator
+/-- Returns a list of up to `limit` elements produced by the enumerator
     associated with the `Enum` instance for a type,
     using `size` as the size parameter for the enumerator.
     To invoke this function, you will need to specify what type `α` is,
     for example by doing `runEnum (α := Nat) 10`. -/
-def runEnum [Enum α] (size : Nat) : IO (List α) :=
-  return (LazyList.toList $ Enum.enum size)
+def runEnum [Enum α] (size : Nat) (limit : Nat := 10) : IO (List α) :=
+  return (LazyList.toList $ LazyList.take limit $ Enum.enum size)
 
 /-- Samples from an `OptionT Enumerator` enumerator that is parameterized by its `size`,
-    returning the enumerated list of `Option α` values in the `IO` monad
-    - TODO: investigate why there are many duplicate values in the resultant `LazyList` -/
-def runSizedEnum (sizedEnum : Nat → OptionT Enumerator α) (size : Nat) : IO (List (Option α)) :=
-  return (LazyList.toList $ (sizedEnum size) size)
+    returning the enumerated list of `Option α` values (containing up to `limit` elements) in the `IO` monad -/
+def runSizedEnum (sizedEnum : Nat → OptionT Enumerator α) (size : Nat) (limit : Nat := 10) : IO (List (Option α)) :=
+  return (LazyList.toList $ LazyList.take limit $ (sizedEnum size) size)

--- a/Plausible/Chamelean/Enumerators.lean
+++ b/Plausible/Chamelean/Enumerators.lean
@@ -72,15 +72,6 @@ instance [EnumSized α] : Enum α where
 instance [EnumSizedSuchThat α P] : EnumSuchThat α P where
   enumST := sizedEnum (EnumSizedSuchThat.enumSizedST P)
 
-
-/-- `vectorOf k e` creates an enumerator of lists of length `k`,
-     where each element in the list comes from the enumerator `e` -/
-def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
-  List.foldr (fun m m' => do
-    let x ← m
-    let xs ← m'
-    return x::xs) (init := pure []) (List.replicate k e)
-
 /-- Produces a `LazyList` containing all `Int`s in-between
     `lo` and `hi` (inclusive) in ascending order -/
 def lazyListNatRange (lo : Nat) (hi : Nat) : LazyList Nat :=
@@ -95,14 +86,26 @@ def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
 instance : EnumSized Nat where
   enumSized (n : Nat) := enumNatRange 0 n
 
-/-- Picks one of the enumerators in `es`, returning the `default` enumerator
-    if `es` is empty. -/
-def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
-  match es with
-  | [] => default
-  | _ => do
-    let idx ← enumNatRange 0 (es.length - 1)
-    List.getD es idx default
+namespace EnumeratorCombinators
+
+  /-- `vectorOf k e` creates an enumerator of lists of length `k`,
+      where each element in the list comes from the enumerator `e` -/
+  def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
+    List.foldr (fun m m' => do
+      let x ← m
+      let xs ← m'
+      return x::xs) (init := pure []) (List.replicate k e)
+
+  /-- Picks one of the enumerators in `es`, returning the `default` enumerator
+      if `es` is empty. -/
+  def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
+    match es with
+    | [] => default
+    | _ => do
+      let idx ← enumNatRange 0 (es.length - 1)
+      List.getD es idx default
+
+end EnumeratorCombinators
 
 -- Some simple `Enum` instances
 
@@ -112,7 +115,7 @@ instance : Enum Bool where
 
 /-- `Enum` instance for `Option`s -/
 instance [Enum α] : Enum (Option α) where
-  enum := oneOfWithDefault (pure none) [
+  enum := EnumeratorCombinators.oneOfWithDefault (pure none) [
     pure none,
     some <$> Enum.enum
   ]
@@ -144,7 +147,7 @@ instance : Enum Int where
 instance [Enum α] : EnumSized (List α) where
   enumSized (n : Nat) := do
     let x ← enumNatRange 0 n
-    vectorOf x Enum.enum
+    EnumeratorCombinators.vectorOf x Enum.enum
 
 /-- Enumerates all printable ASCII characters (codepoint 32 - 95) -/
 def enumPrintableASCII (size : Nat) : LazyList Char :=

--- a/Plausible/Chamelean/Enumerators.lean
+++ b/Plausible/Chamelean/Enumerators.lean
@@ -78,10 +78,6 @@ instance [EnumSizedSuchThat α P] : EnumSuchThat α P where
 instance : Enum Bool where
   enum := pureEnum false <|> pureEnum true
 
-/-- `Enum` instance for `Nat` -/
-instance : Enum Nat where
-  enum := fun n => lazySeq .succ 0 (n + 1)
-
 /-- `Enum` instance for `Option`s -/
 instance [Enum α] : Enum (Option α) where
   enum := fun n =>
@@ -99,22 +95,44 @@ instance [Enum α] [Enum β] : Enum (α ⊕ β) where
   enum := fun n =>
     (Enum.enum n >>= pure ∘ Sum.inl) <|> (Enum.enum n >>= pure ∘ Sum.inr)
 
-/-- Helper function: enumerates lists with a certain `budget` that is
-    halved during each recursive calls -/
-def enumListsWithBudget [Enum α] (budget : Nat) : LazyList (List α) :=
-  let empty := LazyList.singleton []
-  match budget with
-  | 0 => empty
-  | .succ budget' =>
-    let non_empty := do
-      let hd ← Enum.enum budget
-      let tl ← enumListsWithBudget (budget' / 2)
-      pure (hd :: tl)
-    empty <|> non_empty
+/-- Produces a `LazyList` containing all `Int`s in-between
+    `lo` and `hi` (inclusive) in ascending order -/
+def lazyListNatRange (lo : Nat) (hi : Nat) : LazyList Nat :=
+  lazySeq .succ lo (.succ (hi - lo))
 
-/-- `Enum` instances for lists -/
-instance [Enum α] : Enum (List α) where
-  enum := sizedEnum (fun size => (fun _ => enumListsWithBudget size))
+/-- Enumerates all `Nat`s in-between `lo` and `hi` (inclusive)
+    in ascending order -/
+def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
+  fun _ => lazyListNatRange lo hi
+
+/-- `EnumSized` instance for `Nat` -/
+instance : EnumSized Nat where
+  enumSized (n : Nat) := enumNatRange 0 n
+
+/-- Produces a `LazyList` containing all `Int`s in-between
+    `lo` and `hi` (inclusive) in ascending order -/
+def lazyListIntRange (lo : Int) (hi : Int) : LazyList Int :=
+  lazySeq (. + 1) lo (Int.toNat (hi - lo + 1))
+
+/-- `Enum` instance for `Int` (enumerates all `int`s between `-size` and `size` inclusive) -/
+instance : Enum Int where
+  enum := fun size =>
+    let n := Int.ofNat size
+    lazyListIntRange (-n) n
+
+/-- `vectorOf k e` creates an enumerator of lists of length `k`,
+     where each element in the list comes from the enumerator `e` -/
+def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
+  List.foldr (fun m m' => do
+    let x ← m
+    let xs ← m'
+    return x::xs) (init := pure []) (List.replicate k e)
+
+/-- `EnumSized` instance for lists -/
+instance [Enum α] : EnumSized (List α) where
+  enumSized (n : Nat) := do
+    let x ← enumNatRange 0 n
+    vectorOf x Enum.enum
 
 /-- Enumerates all printable ASCII characters (codepoint 32 - 95) -/
 def enumPrintableASCII (size : Nat) : LazyList Char :=
@@ -127,27 +145,6 @@ instance : Enum Char where
 /-- `Enum` instance for `String`s containing ASCII-printable characters -/
 instance : Enum String where
   enum := List.asString <$> (Enum.enum : Enumerator (List Char))
-
-/-- Produces a `LazyList` containing all `Int`s in-between
-    `lo` and `hi` (inclusive) in ascending order -/
-def lazyListNatRange (lo : Nat) (hi : Nat) : LazyList Nat :=
-  lazySeq .succ lo (.succ (hi - lo))
-
-/-- Enumerates all `Nat`s in-between `lo` and `hi` (inclusive)
-    in ascending order -/
-def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
-  fun _ => lazyListNatRange lo hi
-
-/-- Produces a `LazyList` containing all `Int`s in-between
-    `lo` and `hi` (inclusive) in ascending order -/
-def lazyListIntRange (lo : Int) (hi : Int) : LazyList Int :=
-  lazySeq (. + 1) lo (Int.toNat (hi - lo + 1))
-
-/-- `Enum` instance for `Int` (enumerates all `int`s between `-size` and `size` inclusive) -/
-instance : Enum Int where
-  enum := fun size =>
-    let n := Int.ofNat size
-    lazyListIntRange (-n) n
 
 /-- `Enum` instance for `Fin n` where `n > 0`
   (enumerates all `Nat`s from 0 to `n - 1` inclusive) -/

--- a/Plausible/Chamelean/Enumerators.lean
+++ b/Plausible/Chamelean/Enumerators.lean
@@ -8,6 +8,25 @@ open LazyList
     contains all inhabitants of `α` up to the given size. -/
 abbrev Enumerator (α : Type) := Nat → LazyList α
 
+/-- The `Enum` typeclass describes types that have an associated `Enumerator` -/
+class Enum (α : Type) where
+  enum : Enumerator α
+
+/-- The `EnumSized` typeclass describes enumerators that have an
+    additional `Nat` parameter to bound their recursion depth. -/
+class EnumSized (α : Type) where
+  enumSized : Nat → Enumerator α
+
+/-- Sized enumerators of type `α` such that `P : α -> Prop` holds for all enumerated values.
+    Note that these enumerators may fail, which is why they have type `OptionT Enumerator α`. -/
+class EnumSizedSuchThat (α : Type) (P : α → Prop) where
+  enumSizedST : Nat → OptionT Enumerator α
+
+/-- Enumerators of type `α` such that `P : α -> Prop` holds for all generated values.
+    Note that these enumerators may fail, which is why they have type `OptionT Enumerator α`. -/
+class EnumSuchThat (α : Type) (P : α → Prop) where
+  enumST : OptionT Enumerator α
+
 /-- `pure x` constructs a trivial enumerator which produces a singleton `LazyList` containing `x` -/
 def pureEnum (x : α) : Enumerator α :=
   fun _ => pureLazyList x
@@ -45,25 +64,6 @@ instance : Alternative Enumerator where
 def sizedEnum (f : Nat → Enumerator α) : Enumerator α :=
   fun (n : Nat) => (f n) n
 
-/-- The `Enum` typeclass describes types that have an associated `Enumerator` -/
-class Enum (α : Type) where
-  enum : Enumerator α
-
-/-- The `EnumSized` typeclass describes enumerators that have an
-    additional `Nat` parameter to bound their recursion depth. -/
-class EnumSized (α : Type) where
-  enumSized : Nat → Enumerator α
-
-/-- Sized enumerators of type `α` such that `P : α -> Prop` holds for all enumerated values.
-    Note that these enumerators may fail, which is why they have type `OptionT Enumerator α`. -/
-class EnumSizedSuchThat (α : Type) (P : α → Prop) where
-  enumSizedST : Nat → OptionT Enumerator α
-
-/-- Enumerators of type `α` such that `P : α -> Prop` holds for all generated values.
-    Note that these enumerators may fail, which is why they have type `OptionT Enumerator α`. -/
-class EnumSuchThat (α : Type) (P : α → Prop) where
-  enumST : OptionT Enumerator α
-
 /-- Every `EnumSized` instance gives rise to an `Enum` instance -/
 instance [EnumSized α] : Enum α where
   enum := sizedEnum EnumSized.enumSized
@@ -72,28 +72,14 @@ instance [EnumSized α] : Enum α where
 instance [EnumSizedSuchThat α P] : EnumSuchThat α P where
   enumST := sizedEnum (EnumSizedSuchThat.enumSizedST P)
 
--- Some simple `Enum` instances
 
-/-- `Enum` instance for `Bool` -/
-instance : Enum Bool where
-  enum := pureEnum false <|> pureEnum true
-
-/-- `Enum` instance for `Option`s -/
-instance [Enum α] : Enum (Option α) where
-  enum := fun n =>
-    (return none) <|> (some <$> Enum.enum n)
-
-/-- `Enum` instances for pairs -/
-instance [Enum α] [Enum β] : Enum (α × β) where
-  enum := fun n => do
-    let a ← Enum.enum n
-    let b ← Enum.enum n
-    pure (a, b)
-
-/-- `Enum` instances for sums -/
-instance [Enum α] [Enum β] : Enum (α ⊕ β) where
-  enum := fun n =>
-    (Enum.enum n >>= pure ∘ Sum.inl) <|> (Enum.enum n >>= pure ∘ Sum.inr)
+/-- `vectorOf k e` creates an enumerator of lists of length `k`,
+     where each element in the list comes from the enumerator `e` -/
+def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
+  List.foldr (fun m m' => do
+    let x ← m
+    let xs ← m'
+    return x::xs) (init := pure []) (List.replicate k e)
 
 /-- Produces a `LazyList` containing all `Int`s in-between
     `lo` and `hi` (inclusive) in ascending order -/
@@ -109,6 +95,40 @@ def enumNatRange (lo : Nat) (hi : Nat) : Enumerator Nat :=
 instance : EnumSized Nat where
   enumSized (n : Nat) := enumNatRange 0 n
 
+/-- Picks one of the enumerators in `es`, returning the `default` enumerator
+    if `es` is empty. -/
+def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
+  match es with
+  | [] => default
+  | _ => do
+    let idx ← enumNatRange 0 (es.length - 1)
+    List.getD es idx default
+
+-- Some simple `Enum` instances
+
+/-- `Enum` instance for `Bool` -/
+instance : Enum Bool where
+  enum := pureEnum false <|> pureEnum true
+
+/-- `Enum` instance for `Option`s -/
+instance [Enum α] : Enum (Option α) where
+  enum := oneOfWithDefault (pure none) [
+    pure none,
+    some <$> Enum.enum
+  ]
+
+/-- `Enum` instances for pairs -/
+instance [Enum α] [Enum β] : Enum (α × β) where
+  enum := fun n => do
+    let a ← Enum.enum n
+    let b ← Enum.enum n
+    pure (a, b)
+
+/-- `Enum` instances for sums -/
+instance [Enum α] [Enum β] : Enum (α ⊕ β) where
+  enum := fun n =>
+    (Enum.enum n >>= pure ∘ Sum.inl) <|> (Enum.enum n >>= pure ∘ Sum.inr)
+
 /-- Produces a `LazyList` containing all `Int`s in-between
     `lo` and `hi` (inclusive) in ascending order -/
 def lazyListIntRange (lo : Int) (hi : Int) : LazyList Int :=
@@ -119,14 +139,6 @@ instance : Enum Int where
   enum := fun size =>
     let n := Int.ofNat size
     lazyListIntRange (-n) n
-
-/-- `vectorOf k e` creates an enumerator of lists of length `k`,
-     where each element in the list comes from the enumerator `e` -/
-def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
-  List.foldr (fun m m' => do
-    let x ← m
-    let xs ← m'
-    return x::xs) (init := pure []) (List.replicate k e)
 
 /-- `EnumSized` instance for lists -/
 instance [Enum α] : EnumSized (List α) where

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -91,7 +91,6 @@ def concatCPS (l : LazyList (LazyList α)) : LazyList α :=
 def concat (l : LazyList (LazyList α)) : LazyList α :=
   concatCPS l
 
-
 /-- Bind for `LazyList`s is just `concatMap` (same as the list monad) -/
 def bindLazyList (l : LazyList α) (f : α → LazyList β) : LazyList β :=
   concat (f <$> l)

--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -301,8 +301,9 @@ mutual
             else
               mkTuple vars
           -- If a checker invokes a contrained enumerator,
-          -- we call `EnumeratorCombinators.enumeratingOpt`
-          `($enumeratingOptFn $m1:term (fun $args:term => $k1:term) $initSizeIdent)
+          -- we call `EnumeratorCombinators.enumeratingOpt`.
+          -- We pass in `(min 2 initSize)` as the amount of fuel for the enumerator to avoid stack-overflow
+          `($enumeratingOptFn $m1:term (fun $args:term => $k1:term) ($(mkIdent `min) 2 $initSizeIdent))
       | .Theorem, _ => throwError "Theorem DeriveSort not implemented yet"
       | _, _ => throwError m!"Invalid monadic bind for deriveSort {repr deriveSort}"
     | .MMatch scrutinee cases => do

--- a/Test/DeriveDecOpt/DerivePermutationChecker.lean
+++ b/Test/DeriveDecOpt/DerivePermutationChecker.lean
@@ -56,8 +56,14 @@ info: Try this checker: instance : DecOpt (Permutation l_1 l'_1) where
             | _ => Option.some Bool.false,
             fun _ =>
             EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l_1 l') initSize)
-              (fun l' => aux_dec initSize size' l' l'_1) initSize]
+              (fun l' => aux_dec initSize size' l' l'_1) (min 2 initSize)]
     fun size => aux_dec size size l_1 l'_1
 -/
 #guard_msgs(info, drop warning) in
 #derive_checker (Permutation l l')
+
+
+-- Example: to run the derived checker, you can uncomment the following
+-- def l := [1, 2, 3, 4]
+-- def l' := [2, 1, 3, 4]
+-- #eval (DecOpt.decOpt (Permutation l l')) 2

--- a/Test/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/Test/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -61,7 +61,7 @@ info: Try this checker: instance : DecOpt (typing Γ_1 e_1 τ_1) where
             match e_1 with
             | term.App e1 e2 =>
               EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun τ1 => typing Γ_1 e2 τ1) initSize)
-                (fun τ1 => aux_dec initSize size' Γ_1 e1 (type.Fun τ1 τ_1)) initSize
+                (fun τ1 => aux_dec initSize size' Γ_1 e1 (type.Fun τ1 τ_1)) (min 2 initSize)
             | _ => Option.some Bool.false]
     fun size => aux_dec size size Γ_1 e_1 τ_1
 -/

--- a/Test/DeriveDecOpt/ExistentialVariablesTest.lean
+++ b/Test/DeriveDecOpt/ExistentialVariablesTest.lean
@@ -89,16 +89,16 @@ info: Try this checker: instance : DecOpt (NatChain a_1 b_1) where
             EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun x => LessThanEq a_1 x) initSize)
               (fun x =>
                 EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun y => LessThanEq x y) initSize)
-                  (fun y => DecOpt.decOpt (LessThanEq y b_1) initSize) initSize)
-              initSize]
+                  (fun y => DecOpt.decOpt (LessThanEq y b_1) initSize) (min 2 initSize))
+              (min 2 initSize)]
       | Nat.succ size' =>
         DecOpt.checkerBacktrack
           [fun _ =>
             EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun x => LessThanEq a_1 x) initSize)
               (fun x =>
                 EnumeratorCombinators.enumeratingOpt (EnumSizedSuchThat.enumSizedST (fun y => LessThanEq x y) initSize)
-                  (fun y => DecOpt.decOpt (LessThanEq y b_1) initSize) initSize)
-              initSize,
+                  (fun y => DecOpt.decOpt (LessThanEq y b_1) initSize) (min 2 initSize))
+              (min 2 initSize),
             ]
     fun size => aux_dec size size a_1 b_1
 -/

--- a/Test/DeriveDecOpt/FunctionCallsTest.lean
+++ b/Test/DeriveDecOpt/FunctionCallsTest.lean
@@ -22,13 +22,13 @@ info: Try this checker: instance : DecOpt (square_of n_1 m_1) where
           [fun _ =>
             EnumeratorCombinators.enumeratingOpt
               (EnumSizedSuchThat.enumSizedST (fun m_1 => Eq m_1 (HMul.hMul n_1 n_1)) initSize)
-              (fun m_1 => Option.some Bool.true) initSize]
+              (fun m_1 => Option.some Bool.true) (min 2 initSize)]
       | Nat.succ size' =>
         DecOpt.checkerBacktrack
           [fun _ =>
             EnumeratorCombinators.enumeratingOpt
               (EnumSizedSuchThat.enumSizedST (fun m_1 => Eq m_1 (HMul.hMul n_1 n_1)) initSize)
-              (fun m_1 => Option.some Bool.true) initSize,
+              (fun m_1 => Option.some Bool.true) (min 2 initSize),
             ]
     fun size => aux_dec size size n_1 m_1
 -/

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -77,4 +77,4 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 
 def l := [1, 2, 3]
 
-#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 1
+#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 3

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -74,3 +74,7 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 -/
 #guard_msgs(info, drop warning) in
 #derive_enumerator (fun (l : List Nat) => Permutation l' l)
+
+def l := [1, 2, 3]
+
+#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 1

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -74,7 +74,3 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 -/
 #guard_msgs(info, drop warning) in
 #derive_enumerator (fun (l : List Nat) => Permutation l' l)
-
-def l := [1, 2, 3]
-
--- #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 2

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -77,4 +77,4 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 
 def l := [1, 2, 3]
 
-#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 2
+-- #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 2

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -77,4 +77,4 @@ info: Try this enumerator: instance : EnumSizedSuchThat (List Nat) (fun l_1 => P
 
 def l := [1, 2, 3]
 
-#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 3
+#eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun l' => Permutation l l')) 2

--- a/Test/Enum/EnumInstancesTest.lean
+++ b/Test/Enum/EnumInstancesTest.lean
@@ -1,6 +1,6 @@
 import Plausible.Chamelean.Enumerators
 
-/-- info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] -/
+/-- info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] -/
 #guard_msgs in
 #eval (runEnum (α := Nat) 15)
 
@@ -22,8 +22,7 @@ import Plausible.Chamelean.Enumerators
 #eval (runEnum (α := Bool) 10)
 
 /--
-info: [(0, false), (0, true), (1, false), (1, true), (2, false), (2, true), (3, false), (3, true), (4, false), (4, true),
-  (5, false), (5, true)]
+info: [(0, false), (0, true), (1, false), (1, true), (2, false), (2, true), (3, false), (3, true), (4, false), (4, true)]
 -/
 #guard_msgs in
 #eval (runEnum (α := Nat × Bool) 5)
@@ -34,14 +33,10 @@ info: [Sum.inl 0, Sum.inl 1, Sum.inl 2, Sum.inl 3, Sum.inl 4, Sum.inl 5, Sum.inr
 #guard_msgs in
 #eval (runEnum (α := Nat ⊕ Bool) 5)
 
-/--
-info: [[], [0], [0, 0], [0, 1], [1], [1, 0], [1, 1], [2], [2, 0], [2, 1], [3], [3, 0], [3, 1]]
--/
+/-- info: [[], [0], [1], [2], [3], [0, 0], [0, 1], [0, 2], [0, 3], [1, 0]] -/
 #guard_msgs in
 #eval (runEnum (α := List Nat) 3)
 
-/--
-info: [' ', '!', '\"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', '0', '1', '2', '3']
--/
+/-- info: [' ', '!', '\"', '#', '$', '%', '&', '\'', '(', ')'] -/
 #guard_msgs in
 #eval (runEnum (α := Char) 20)


### PR DESCRIPTION
- When executing an enumerator via `runEnum` / `runSizedEnum`, we extract a prefix of length 10 in the resultant list to avoid stack overflow.
- When a checker invokes a constrained enumerator (e.g. for existentially quantified variables), we pass in `min 2 initSize` as the fuel for the enumerator -- passing in too much fuel to the enumerator causes it to stack overflow. Snapshot tests for constrained enumerators have been updated to reflect this.