### PR TITLE
Add `ArbitrarySuchThat` snapshot test for mutually recursive relations

### DIFF
--- a/Test.lean
+++ b/Test.lean
@@ -20,6 +20,7 @@ import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
 import Test.DeriveArbitrarySuchThat.SimultaneousMatchingTests
 import Test.DeriveArbitrarySuchThat.FunctionCallsTest
 import Test.DeriveArbitrarySuchThat.DerivePermutationGenerator
+import Test.DeriveArbitrarySuchThat.MutuallyRecursiveRelationsTest
 
 -- Tests for `deriving Arbitrary`
 import Test.DeriveArbitrary.DeriveTreeGenerator

--- a/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
@@ -1,0 +1,59 @@
+
+import Plausible.Arbitrary
+import Plausible.Chamelean.ArbitrarySizedSuchThat
+import Plausible.Chamelean.DeriveConstrainedProducer
+
+set_option guard_msgs.diff true
+
+mutual
+  inductive Even : Nat → Prop where
+    | zero_is_even : Even .zero
+    | succ_of_odd_is_even : ∀ n : Nat, Odd n → Even (.succ n)
+
+  inductive Odd : Nat → Prop where
+    | succ_of_even_is_odd : ∀ n : Nat, Even n → Odd (.succ n)
+end
+
+/--
+info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Odd n_1) where
+  arbitrarySizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) : OptionT Plausible.Gen Nat :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
+              return Nat.succ n)]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
+              return Nat.succ n),
+            ]
+    fun size => aux_arb size size
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (n : Nat) => Odd n)
+
+/--
+info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Even n_1) where
+  arbitrarySizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) : OptionT Plausible.Gen Nat :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1, return Nat.zero),
+            (1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Odd n) initSize;
+              return Nat.succ n)]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1, return Nat.zero),
+            (1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Odd n) initSize;
+              return Nat.succ n),
+            ]
+    fun size => aux_arb size size
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (n : Nat) => Even n)

--- a/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
@@ -14,26 +14,14 @@ mutual
     | succ_of_even_is_odd : ∀ n : Nat, Even n → Odd (.succ n)
 end
 
-/--
-info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Odd n_1) where
-  arbitrarySizedST :=
-    let rec aux_arb (initSize : Nat) (size : Nat) : OptionT Plausible.Gen Nat :=
-      match size with
-      | Nat.zero =>
-        OptionTGen.backtrack
-          [(1, do
-              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
-              return Nat.succ n)]
-      | Nat.succ size' =>
-        OptionTGen.backtrack
-          [(1, do
-              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
-              return Nat.succ n),
-            ]
-    fun size => aux_arb size size
--/
-#guard_msgs(info, drop warning) in
-#derive_generator (fun (n : Nat) => Odd n)
+/-- To make the derived generators below compile, we need to
+    manually add a dummy instance of `ArbitrarySizedSuchThat` for one of the relations, since Lean doesn't support
+    mutually recursively typeclass instances currently.
+
+    Note that the instance of `ArbitrarySizedSuchThat` for `Odd` below (produced by `#derive_generator`)
+    will shadow this one -- it takes precedence over this dummy instance. -/
+instance : ArbitrarySizedSuchThat Nat (fun n => Odd n) where
+  arbitrarySizedST (_ : Nat) := return 1
 
 /--
 info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Even n_1) where
@@ -57,3 +45,24 @@ info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Even
 -/
 #guard_msgs(info, drop warning) in
 #derive_generator (fun (n : Nat) => Even n)
+
+/--
+info: Try this generator: instance : ArbitrarySizedSuchThat Nat (fun n_1 => Odd n_1) where
+  arbitrarySizedST :=
+    let rec aux_arb (initSize : Nat) (size : Nat) : OptionT Plausible.Gen Nat :=
+      match size with
+      | Nat.zero =>
+        OptionTGen.backtrack
+          [(1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
+              return Nat.succ n)]
+      | Nat.succ size' =>
+        OptionTGen.backtrack
+          [(1, do
+              let n ← ArbitrarySizedSuchThat.arbitrarySizedST (fun n => Even n) initSize;
+              return Nat.succ n),
+            ]
+    fun size => aux_arb size size
+-/
+#guard_msgs(info, drop warning) in
+#derive_generator (fun (n : Nat) => Odd n)


### PR DESCRIPTION
This PR adds a snapshot test which tests the derived generators for the following pair of mutually recursive relations: 

```lean 
mutual
  inductive Even : Nat → Prop where
    | zero_is_even : Even .zero
    | succ_of_odd_is_even : ∀ n : Nat, Odd n → Even (.succ n)

  inductive Odd : Nat → Prop where
    | succ_of_even_is_odd : ∀ n : Nat, Even n → Odd (.succ n)
end
```